### PR TITLE
feat: add admin currency and market pages

### DIFF
--- a/apps/crm-frontend/src/App.tsx
+++ b/apps/crm-frontend/src/App.tsx
@@ -6,6 +6,8 @@ import Users from './pages/Users';
 import Deposits from './pages/Deposits';
 import Withdrawals from './pages/Withdrawals';
 import Placeholder from './pages/Placeholder';
+import AdminCurrencies from './pages/admin/currencies';
+import AdminMarkets from './pages/admin/markets';
 
 export default function App() {
   const [token, setToken] = useState<string | null>(localStorage.getItem('token'));
@@ -16,6 +18,8 @@ export default function App() {
       <Route path="/users" element={token ? <Users /> : <Navigate to="/login" />} />
       <Route path="/deposits" element={token ? <Deposits /> : <Navigate to="/login" />} />
       <Route path="/withdrawals" element={token ? <Withdrawals /> : <Navigate to="/login" />} />
+      <Route path="/admin/currencies" element={token ? <AdminCurrencies /> : <Navigate to="/login" />} />
+      <Route path="/admin/markets" element={token ? <AdminMarkets /> : <Navigate to="/login" />} />
       <Route path="/trading/spot" element={token ? <Placeholder title="Trading Spot" /> : <Navigate to="/login" />} />
       <Route path="/trading/futures" element={token ? <Placeholder title="Trading Futures" /> : <Navigate to="/login" />} />
       <Route path="/trading/binary" element={token ? <Placeholder title="Trading Binary" /> : <Navigate to="/login" />} />

--- a/apps/crm-frontend/src/api/currencies.ts
+++ b/apps/crm-frontend/src/api/currencies.ts
@@ -1,0 +1,34 @@
+import { apiFetch } from './client';
+
+export interface CurrencyComment {
+  id: string;
+  comment: string;
+  createdAt: string;
+}
+
+export interface Currency {
+  id: string;
+  code: string;
+  enabled: boolean;
+  comments?: CurrencyComment[];
+}
+
+export async function listCurrencies(): Promise<{ data: Currency[] }> {
+  return apiFetch('/internal/currencies');
+}
+
+export async function updateCurrencyStatus(id: string, enabled: boolean, comment: string) {
+  return apiFetch(`/internal/currencies/${id}/status`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ enabled, comment }),
+  });
+}
+
+export async function addCurrencyComment(id: string, comment: string) {
+  return apiFetch(`/internal/currencies/${id}/comments`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ comment }),
+  });
+}

--- a/apps/crm-frontend/src/api/markets.ts
+++ b/apps/crm-frontend/src/api/markets.ts
@@ -1,0 +1,34 @@
+import { apiFetch } from './client';
+
+export interface MarketComment {
+  id: string;
+  comment: string;
+  createdAt: string;
+}
+
+export interface Market {
+  id: string;
+  symbol: string;
+  enabled: boolean;
+  comments?: MarketComment[];
+}
+
+export async function listMarkets(): Promise<{ data: Market[] }> {
+  return apiFetch('/internal/markets');
+}
+
+export async function updateMarketStatus(id: string, enabled: boolean, comment: string) {
+  return apiFetch(`/internal/markets/${id}/status`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ enabled, comment }),
+  });
+}
+
+export async function addMarketComment(id: string, comment: string) {
+  return apiFetch(`/internal/markets/${id}/comments`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ comment }),
+  });
+}

--- a/apps/crm-frontend/src/pages/admin/currencies/index.tsx
+++ b/apps/crm-frontend/src/pages/admin/currencies/index.tsx
@@ -1,0 +1,63 @@
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Switch, TextField, Button } from '@mui/material';
+import { listCurrencies, updateCurrencyStatus, addCurrencyComment } from '../../../api/currencies';
+
+export default function AdminCurrencies() {
+  const { data } = useQuery({ queryKey: ['currencies'], queryFn: listCurrencies });
+  const qc = useQueryClient();
+  const [inputs, setInputs] = useState<Record<string, string>>({});
+
+  const statusMutation = useMutation({
+    mutationFn: ({ id, enabled, comment }: { id: string; enabled: boolean; comment: string }) =>
+      updateCurrencyStatus(id, enabled, comment),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['currencies'] }),
+  });
+
+  const commentMutation = useMutation({
+    mutationFn: ({ id, comment }: { id: string; comment: string }) => addCurrencyComment(id, comment),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['currencies'] }),
+  });
+
+  const handleToggle = (id: string, enabled: boolean) => {
+    const comment = window.prompt('Comment for status change?') || '';
+    statusMutation.mutate({ id, enabled, comment });
+  };
+
+  return (
+    <div>
+      <h1>Currencies</h1>
+      {data?.data?.map((c) => (
+        <div key={c.id} style={{ border: '1px solid #ccc', margin: '1rem 0', padding: '0.5rem' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+            <strong>{c.code}</strong>
+            <Switch checked={c.enabled} onChange={() => handleToggle(c.id, !c.enabled)} />
+          </div>
+          <ul>
+            {c.comments?.map((cm) => (
+              <li key={cm.id}>{cm.comment}</li>
+            ))}
+          </ul>
+          <div style={{ display: 'flex', gap: '0.5rem' }}>
+            <TextField
+              size="small"
+              value={inputs[c.id] || ''}
+              onChange={(e) => setInputs({ ...inputs, [c.id]: e.target.value })}
+            />
+            <Button
+              variant="contained"
+              onClick={() => {
+                const text = inputs[c.id];
+                if (!text) return;
+                commentMutation.mutate({ id: c.id, comment: text });
+                setInputs({ ...inputs, [c.id]: '' });
+              }}
+            >
+              Add Comment
+            </Button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/crm-frontend/src/pages/admin/markets/index.tsx
+++ b/apps/crm-frontend/src/pages/admin/markets/index.tsx
@@ -1,0 +1,63 @@
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Switch, TextField, Button } from '@mui/material';
+import { listMarkets, updateMarketStatus, addMarketComment } from '../../../api/markets';
+
+export default function AdminMarkets() {
+  const { data } = useQuery({ queryKey: ['markets'], queryFn: listMarkets });
+  const qc = useQueryClient();
+  const [inputs, setInputs] = useState<Record<string, string>>({});
+
+  const statusMutation = useMutation({
+    mutationFn: ({ id, enabled, comment }: { id: string; enabled: boolean; comment: string }) =>
+      updateMarketStatus(id, enabled, comment),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['markets'] }),
+  });
+
+  const commentMutation = useMutation({
+    mutationFn: ({ id, comment }: { id: string; comment: string }) => addMarketComment(id, comment),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['markets'] }),
+  });
+
+  const handleToggle = (id: string, enabled: boolean) => {
+    const comment = window.prompt('Comment for status change?') || '';
+    statusMutation.mutate({ id, enabled, comment });
+  };
+
+  return (
+    <div>
+      <h1>Markets</h1>
+      {data?.data?.map((m) => (
+        <div key={m.id} style={{ border: '1px solid #ccc', margin: '1rem 0', padding: '0.5rem' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+            <strong>{m.symbol}</strong>
+            <Switch checked={m.enabled} onChange={() => handleToggle(m.id, !m.enabled)} />
+          </div>
+          <ul>
+            {m.comments?.map((cm) => (
+              <li key={cm.id}>{cm.comment}</li>
+            ))}
+          </ul>
+          <div style={{ display: 'flex', gap: '0.5rem' }}>
+            <TextField
+              size="small"
+              value={inputs[m.id] || ''}
+              onChange={(e) => setInputs({ ...inputs, [m.id]: e.target.value })}
+            />
+            <Button
+              variant="contained"
+              onClick={() => {
+                const text = inputs[m.id];
+                if (!text) return;
+                commentMutation.mutate({ id: m.id, comment: text });
+                setInputs({ ...inputs, [m.id]: '' });
+              }}
+            >
+              Add Comment
+            </Button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add API clients for currencies and markets
- add admin pages with status toggles and comment inputs
- wire up routes for new admin pages

## Testing
- `npm run build -w apps/crm-frontend`


------
https://chatgpt.com/codex/tasks/task_e_68a73c84dd0483229d83427a78bc7024