### PR TITLE
feat: add admin pages with notifications and reports

### DIFF
--- a/vite-template-typescript/src/api/admin.ts
+++ b/vite-template-typescript/src/api/admin.ts
@@ -1,0 +1,81 @@
+import axios from "axios";
+
+// Types for admin related resources
+export interface AdminMetric {
+  label: string;
+  value: number;
+}
+
+export interface Comment {
+  id: string;
+  content: string;
+  author: { name: string; avatar?: string };
+  createdAt: Date;
+}
+
+export interface Notification {
+  id: string;
+  message: string;
+  status: "open" | "resolved";
+  comments: Comment[];
+}
+
+export interface BugReport {
+  id: string;
+  title: string;
+  status: "open" | "resolved";
+  comments: Comment[];
+}
+
+const api = axios.create({ baseURL: "/api/admin" });
+
+export async function getAdminMetrics(): Promise<AdminMetric[]> {
+  const response = await api.get("/metrics");
+  return response.data;
+}
+
+export async function getNotifications(): Promise<Notification[]> {
+  const response = await api.get("/notifications");
+  return response.data.map((n: Notification) => ({
+    ...n,
+    comments: n.comments.map((c) => ({ ...c, createdAt: new Date(c.createdAt) })),
+  }));
+}
+
+export async function updateNotificationStatus(
+  id: string,
+  status: "open" | "resolved"
+): Promise<void> {
+  await api.patch(`/notifications/${id}`, { status });
+}
+
+export async function addNotificationComment(
+  id: string,
+  content: string
+): Promise<Comment> {
+  const response = await api.post(`/notifications/${id}/comments`, { content });
+  return { ...response.data, createdAt: new Date(response.data.createdAt) };
+}
+
+export async function getBugReports(): Promise<BugReport[]> {
+  const response = await api.get("/bug-reports");
+  return response.data.map((r: BugReport) => ({
+    ...r,
+    comments: r.comments.map((c) => ({ ...c, createdAt: new Date(c.createdAt) })),
+  }));
+}
+
+export async function updateBugReportStatus(
+  id: string,
+  status: "open" | "resolved"
+): Promise<void> {
+  await api.patch(`/bug-reports/${id}`, { status });
+}
+
+export async function addBugReportComment(
+  id: string,
+  content: string
+): Promise<Comment> {
+  const response = await api.post(`/bug-reports/${id}/comments`, { content });
+  return { ...response.data, createdAt: new Date(response.data.createdAt) };
+}

--- a/vite-template-typescript/src/components/admin/comment-thread.tsx
+++ b/vite-template-typescript/src/components/admin/comment-thread.tsx
@@ -1,0 +1,47 @@
+import * as React from "react";
+import Button from "@mui/material/Button";
+import Stack from "@mui/material/Stack";
+import TextField from "@mui/material/TextField";
+
+import { CommentBox } from "@/components/dashboard/social/comment-box";
+import type { Comment } from "@/api/admin";
+
+export interface CommentThreadProps {
+  comments: Comment[];
+  onAdd?: (content: string) => void;
+}
+
+export function CommentThread({ comments, onAdd }: CommentThreadProps): React.JSX.Element {
+  const [value, setValue] = React.useState("");
+
+  const handleSubmit = (): void => {
+    const content = value.trim();
+    if (!content) {
+      return;
+    }
+    onAdd?.(content);
+    setValue("");
+  };
+
+  return (
+    <Stack spacing={2} sx={{ mt: 1 }}>
+      {comments.map((comment) => (
+        <CommentBox comment={comment} key={comment.id} />
+      ))}
+      {onAdd ? (
+        <Stack direction="row" spacing={1} sx={{ alignItems: "center" }}>
+          <TextField
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            placeholder="Add comment"
+            size="small"
+            fullWidth
+          />
+          <Button onClick={handleSubmit} variant="contained">
+            Post
+          </Button>
+        </Stack>
+      ) : null}
+    </Stack>
+  );
+}

--- a/vite-template-typescript/src/pages/admin/dashboard.tsx
+++ b/vite-template-typescript/src/pages/admin/dashboard.tsx
@@ -1,0 +1,60 @@
+import * as React from "react";
+import Box from "@mui/material/Box";
+import Grid from "@mui/material/Grid2";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+import { Helmet } from "react-helmet-async";
+
+import { appConfig } from "@/config/app";
+import { getAdminMetrics, type AdminMetric } from "@/api/admin";
+import type { Metadata } from "@/types/metadata";
+
+const metadata = { title: `Dashboard | Admin | ${appConfig.name}` } satisfies Metadata;
+
+export function Page(): React.JSX.Element {
+  const [metrics, setMetrics] = React.useState<AdminMetric[]>([]);
+
+  React.useEffect(() => {
+    getAdminMetrics()
+      .then((data) => setMetrics(data))
+      .catch(() => setMetrics([]));
+  }, []);
+
+  return (
+    <React.Fragment>
+      <Helmet>
+        <title>{metadata.title}</title>
+      </Helmet>
+      <Box
+        sx={{
+          maxWidth: "var(--Content-maxWidth)",
+          m: "var(--Content-margin)",
+          p: "var(--Content-padding)",
+          width: "var(--Content-width)",
+        }}
+      >
+        <Stack spacing={4}>
+          <Typography variant="h4">Admin dashboard</Typography>
+          <Grid container spacing={3}>
+            {metrics.map((metric) => (
+              <Grid key={metric.label} size={{ xs: 12, sm: 6, md: 4 }}>
+                <Box
+                  sx={{
+                    bgcolor: "var(--mui-palette-background-paper)",
+                    borderRadius: 1,
+                    p: 2,
+                  }}
+                >
+                  <Typography color="text.secondary" variant="overline">
+                    {metric.label}
+                  </Typography>
+                  <Typography variant="h5">{metric.value}</Typography>
+                </Box>
+              </Grid>
+            ))}
+          </Grid>
+        </Stack>
+      </Box>
+    </React.Fragment>
+  );
+}

--- a/vite-template-typescript/src/pages/admin/notifications.tsx
+++ b/vite-template-typescript/src/pages/admin/notifications.tsx
@@ -1,0 +1,99 @@
+import * as React from "react";
+import Box from "@mui/material/Box";
+import Card from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
+import CardHeader from "@mui/material/CardHeader";
+import Stack from "@mui/material/Stack";
+import Switch from "@mui/material/Switch";
+import Typography from "@mui/material/Typography";
+import { Helmet } from "react-helmet-async";
+
+import { appConfig } from "@/config/app";
+import {
+  addNotificationComment,
+  getNotifications,
+  updateNotificationStatus,
+  type Notification,
+} from "@/api/admin";
+import type { Metadata } from "@/types/metadata";
+import { CommentThread } from "@/components/admin/comment-thread";
+
+const metadata = { title: `Notifications | Admin | ${appConfig.name}` } satisfies Metadata;
+
+export function Page(): React.JSX.Element {
+  const [notifications, setNotifications] = React.useState<Notification[]>([]);
+
+  React.useEffect(() => {
+    getNotifications()
+      .then((data) => setNotifications(data))
+      .catch(() => setNotifications([]));
+  }, []);
+
+  const handleStatusChange = async (id: string, checked: boolean): Promise<void> => {
+    const status = checked ? "resolved" : "open";
+    setNotifications((prev) =>
+      prev.map((n) => (n.id === id ? { ...n, status } : n))
+    );
+    try {
+      await updateNotificationStatus(id, status);
+    } catch {
+      // ignore
+    }
+  };
+
+  const handleAddComment = async (id: string, content: string): Promise<void> => {
+    try {
+      const comment = await addNotificationComment(id, content);
+      setNotifications((prev) =>
+        prev.map((n) =>
+          n.id === id ? { ...n, comments: [...n.comments, comment] } : n
+        )
+      );
+    } catch {
+      // ignore
+    }
+  };
+
+  return (
+    <React.Fragment>
+      <Helmet>
+        <title>{metadata.title}</title>
+      </Helmet>
+      <Box
+        sx={{
+          maxWidth: "var(--Content-maxWidth)",
+          m: "var(--Content-margin)",
+          p: "var(--Content-padding)",
+          width: "var(--Content-width)",
+        }}
+      >
+        <Stack spacing={4}>
+          <Typography variant="h4">Notifications</Typography>
+          <Stack spacing={3}>
+            {notifications.map((item) => (
+              <Card key={item.id}>
+                <CardHeader
+                  title={item.message}
+                  action={
+                    <Switch
+                      checked={item.status === "resolved"}
+                      onChange={(event) =>
+                        handleStatusChange(item.id, event.target.checked)
+                      }
+                    />
+                  }
+                />
+                <CardContent>
+                  <CommentThread
+                    comments={item.comments}
+                    onAdd={(content) => handleAddComment(item.id, content)}
+                  />
+                </CardContent>
+              </Card>
+            ))}
+          </Stack>
+        </Stack>
+      </Box>
+    </React.Fragment>
+  );
+}

--- a/vite-template-typescript/src/pages/admin/request-report.tsx
+++ b/vite-template-typescript/src/pages/admin/request-report.tsx
@@ -1,0 +1,99 @@
+import * as React from "react";
+import Box from "@mui/material/Box";
+import Card from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
+import CardHeader from "@mui/material/CardHeader";
+import Stack from "@mui/material/Stack";
+import Switch from "@mui/material/Switch";
+import Typography from "@mui/material/Typography";
+import { Helmet } from "react-helmet-async";
+
+import { appConfig } from "@/config/app";
+import {
+  addBugReportComment,
+  getBugReports,
+  updateBugReportStatus,
+  type BugReport,
+} from "@/api/admin";
+import type { Metadata } from "@/types/metadata";
+import { CommentThread } from "@/components/admin/comment-thread";
+
+const metadata = { title: `Bug reports | Admin | ${appConfig.name}` } satisfies Metadata;
+
+export function Page(): React.JSX.Element {
+  const [reports, setReports] = React.useState<BugReport[]>([]);
+
+  React.useEffect(() => {
+    getBugReports()
+      .then((data) => setReports(data))
+      .catch(() => setReports([]));
+  }, []);
+
+  const handleStatusChange = async (id: string, checked: boolean): Promise<void> => {
+    const status = checked ? "resolved" : "open";
+    setReports((prev) =>
+      prev.map((r) => (r.id === id ? { ...r, status } : r))
+    );
+    try {
+      await updateBugReportStatus(id, status);
+    } catch {
+      // ignore
+    }
+  };
+
+  const handleAddComment = async (id: string, content: string): Promise<void> => {
+    try {
+      const comment = await addBugReportComment(id, content);
+      setReports((prev) =>
+        prev.map((r) =>
+          r.id === id ? { ...r, comments: [...r.comments, comment] } : r
+        )
+      );
+    } catch {
+      // ignore
+    }
+  };
+
+  return (
+    <React.Fragment>
+      <Helmet>
+        <title>{metadata.title}</title>
+      </Helmet>
+      <Box
+        sx={{
+          maxWidth: "var(--Content-maxWidth)",
+          m: "var(--Content-margin)",
+          p: "var(--Content-padding)",
+          width: "var(--Content-width)",
+        }}
+      >
+        <Stack spacing={4}>
+          <Typography variant="h4">Bug reports</Typography>
+          <Stack spacing={3}>
+            {reports.map((item) => (
+              <Card key={item.id}>
+                <CardHeader
+                  title={item.title}
+                  action={
+                    <Switch
+                      checked={item.status === "resolved"}
+                      onChange={(event) =>
+                        handleStatusChange(item.id, event.target.checked)
+                      }
+                    />
+                  }
+                />
+                <CardContent>
+                  <CommentThread
+                    comments={item.comments}
+                    onAdd={(content) => handleAddComment(item.id, content)}
+                  />
+                </CardContent>
+              </Card>
+            ))}
+          </Stack>
+        </Stack>
+      </Box>
+    </React.Fragment>
+  );
+}

--- a/vite-template-typescript/src/paths.ts
+++ b/vite-template-typescript/src/paths.ts
@@ -39,7 +39,7 @@ export const paths = {
 			verifyCode: { centered: "/auth/samples/verify-code/centered", split: "/auth/samples/verify-code/split" },
 		},
 	},
-	dashboard: {
+        dashboard: {
 		overview: "/dashboard",
 		settings: {
 			account: "/dashboard/settings/account",
@@ -109,9 +109,14 @@ export const paths = {
 			profile: { timeline: "/dashboard/social/profile", connections: "/dashboard/social/profile/connections" },
 			feed: "/dashboard/social/feed",
 		},
-		tasks: "/dashboard/tasks",
-	},
-	pdf: { invoice: (invoiceId: string) => `/pdf/invoices/${invoiceId}` },
+                tasks: "/dashboard/tasks",
+        },
+        admin: {
+                dashboard: "/admin/dashboard",
+                notifications: "/admin/notifications",
+                requestReport: "/admin/request-report",
+        },
+        pdf: { invoice: (invoiceId: string) => `/pdf/invoices/${invoiceId}` },
 	components: {
 		index: "/components",
 		buttons: "/components/buttons",

--- a/vite-template-typescript/src/routes/admin.tsx
+++ b/vite-template-typescript/src/routes/admin.tsx
@@ -1,0 +1,40 @@
+import * as React from "react";
+import { Outlet } from "react-router-dom";
+import type { RouteObject } from "react-router-dom";
+
+import { AuthGuard } from "@/components/auth/auth-guard";
+import { Layout as DashboardLayout } from "@/components/dashboard/layout/layout";
+
+export const route: RouteObject = {
+  path: "admin",
+  element: (
+    <AuthGuard>
+      <DashboardLayout>
+        <Outlet />
+      </DashboardLayout>
+    </AuthGuard>
+  ),
+  children: [
+    {
+      path: "dashboard",
+      lazy: async () => {
+        const { Page } = await import("@/pages/admin/dashboard");
+        return { Component: Page };
+      },
+    },
+    {
+      path: "notifications",
+      lazy: async () => {
+        const { Page } = await import("@/pages/admin/notifications");
+        return { Component: Page };
+      },
+    },
+    {
+      path: "request-report",
+      lazy: async () => {
+        const { Page } = await import("@/pages/admin/request-report");
+        return { Component: Page };
+      },
+    },
+  ],
+};

--- a/vite-template-typescript/src/routes/index.tsx
+++ b/vite-template-typescript/src/routes/index.tsx
@@ -9,6 +9,7 @@ import { Layout as MarketingLayout } from "@/components/marketing/layout/layout"
 import { route as authRoute } from "./auth";
 import { route as componentsRoute } from "./components";
 import { route as dashboardRoute } from "./dashboard";
+import { route as adminRoute } from "./admin";
 
 export const routes: RouteObject[] = [
 	{
@@ -76,7 +77,8 @@ export const routes: RouteObject[] = [
 			return { Component: Page };
 		},
 	},
-	authRoute,
-	dashboardRoute,
-	{ path: "*", element: <NotFoundPage /> },
+        authRoute,
+        dashboardRoute,
+        adminRoute,
+        { path: "*", element: <NotFoundPage /> },
 ];


### PR DESCRIPTION
## Summary
- add admin API client for metrics, notifications and bug reports
- create admin dashboard, notifications and request report pages
- support comment threads and status toggles on admin pages

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68a73c7ff8948322adb5b8c538066d90