### PR TITLE
feat: add reusable comment thread component

### DIFF
--- a/apps/crm-frontend/src/App.tsx
+++ b/apps/crm-frontend/src/App.tsx
@@ -5,6 +5,10 @@ import Dashboard from './pages/Dashboard';
 import Users from './pages/Users';
 import Deposits from './pages/Deposits';
 import Withdrawals from './pages/Withdrawals';
+import Orders from './pages/Orders';
+import Trades from './pages/Trades';
+import Notifications from './pages/Notifications';
+import Settings from './pages/Settings';
 import Placeholder from './pages/Placeholder';
 
 export default function App() {
@@ -16,6 +20,9 @@ export default function App() {
       <Route path="/users" element={token ? <Users /> : <Navigate to="/login" />} />
       <Route path="/deposits" element={token ? <Deposits /> : <Navigate to="/login" />} />
       <Route path="/withdrawals" element={token ? <Withdrawals /> : <Navigate to="/login" />} />
+      <Route path="/orders" element={token ? <Orders /> : <Navigate to="/login" />} />
+      <Route path="/trades" element={token ? <Trades /> : <Navigate to="/login" />} />
+      <Route path="/notifications" element={token ? <Notifications /> : <Navigate to="/login" />} />
       <Route path="/trading/spot" element={token ? <Placeholder title="Trading Spot" /> : <Navigate to="/login" />} />
       <Route path="/trading/futures" element={token ? <Placeholder title="Trading Futures" /> : <Navigate to="/login" />} />
       <Route path="/trading/binary" element={token ? <Placeholder title="Trading Binary" /> : <Navigate to="/login" />} />
@@ -28,7 +35,7 @@ export default function App() {
       <Route path="/crm/notes" element={token ? <Placeholder title="CRM Notes" /> : <Navigate to="/login" />} />
       <Route path="/crm/chat" element={token ? <Placeholder title="CRM Staff Chat" /> : <Navigate to="/login" />} />
       <Route path="/reports" element={token ? <Placeholder title="Reports" /> : <Navigate to="/login" />} />
-      <Route path="/settings" element={token ? <Placeholder title="Settings" /> : <Navigate to="/login" />} />
+      <Route path="/settings" element={token ? <Settings /> : <Navigate to="/login" />} />
       <Route path="/system/cron" element={token ? <Placeholder title="System Cron" /> : <Navigate to="/login" />} />
       <Route path="/system/audit" element={token ? <Placeholder title="Audit Logs" /> : <Navigate to="/login" />} />
       <Route path="/system/alerts" element={token ? <Placeholder title="Alerts" /> : <Navigate to="/login" />} />

--- a/apps/crm-frontend/src/api/comments.ts
+++ b/apps/crm-frontend/src/api/comments.ts
@@ -1,0 +1,32 @@
+import { apiFetch } from './client';
+
+export interface Comment {
+  id: string;
+  content: string;
+}
+
+export function listComments(entityId: string): Promise<Comment[]> {
+  return apiFetch(`/api/comments?entityId=${encodeURIComponent(entityId)}`);
+}
+
+export function addComment(entityId: string, content: string): Promise<Comment> {
+  return apiFetch(`/api/comments?entityId=${encodeURIComponent(entityId)}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ content }),
+  });
+}
+
+export function updateComment(entityId: string, id: string, content: string): Promise<Comment> {
+  return apiFetch(`/api/comments/${id}?entityId=${encodeURIComponent(entityId)}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ content }),
+  });
+}
+
+export function deleteComment(entityId: string, id: string): Promise<void> {
+  return apiFetch(`/api/comments/${id}?entityId=${encodeURIComponent(entityId)}`, {
+    method: 'DELETE',
+  });
+}

--- a/apps/crm-frontend/src/components/common/comment-thread.tsx
+++ b/apps/crm-frontend/src/components/common/comment-thread.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from 'react';
+import { listComments, addComment, updateComment, deleteComment, Comment } from '../../api/comments';
+
+interface CommentThreadProps {
+  entityId: string;
+}
+
+export default function CommentThread({ entityId }: CommentThreadProps) {
+  const [comments, setComments] = useState<Comment[]>([]);
+  const [newText, setNewText] = useState('');
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editingText, setEditingText] = useState('');
+
+  useEffect(() => {
+    listComments(entityId).then(setComments).catch(console.error);
+  }, [entityId]);
+
+  const handleAdd = async () => {
+    if (!newText.trim()) return;
+    try {
+      const comment = await addComment(entityId, newText);
+      setComments((prev) => [...prev, comment]);
+      setNewText('');
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      await deleteComment(entityId, id);
+      setComments((prev) => prev.filter((c) => c.id !== id));
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleEdit = async (id: string) => {
+    try {
+      const updated = await updateComment(entityId, id, editingText);
+      setComments((prev) => prev.map((c) => (c.id === id ? updated : c)));
+      setEditingId(null);
+      setEditingText('');
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <div>
+      <h3>Comments</h3>
+      <ul>
+        {comments.map((c) => (
+          <li key={c.id}>
+            {editingId === c.id ? (
+              <>
+                <input value={editingText} onChange={(e) => setEditingText(e.target.value)} />
+                <button onClick={() => handleEdit(c.id)}>Save</button>
+                <button onClick={() => { setEditingId(null); setEditingText(''); }}>Cancel</button>
+              </>
+            ) : (
+              <>
+                <span>{c.content}</span>
+                <button onClick={() => { setEditingId(c.id); setEditingText(c.content); }}>Edit</button>
+                <button onClick={() => handleDelete(c.id)}>Delete</button>
+              </>
+            )}
+          </li>
+        ))}
+      </ul>
+      <div>
+        <input value={newText} onChange={(e) => setNewText(e.target.value)} placeholder="Add comment" />
+        <button onClick={handleAdd}>Add</button>
+      </div>
+    </div>
+  );
+}

--- a/apps/crm-frontend/src/pages/Notifications.tsx
+++ b/apps/crm-frontend/src/pages/Notifications.tsx
@@ -1,0 +1,10 @@
+import CommentThread from '../components/common/comment-thread';
+
+export default function Notifications() {
+  return (
+    <div>
+      <h1>Notifications</h1>
+      <CommentThread entityId="notifications" />
+    </div>
+  );
+}

--- a/apps/crm-frontend/src/pages/Orders.tsx
+++ b/apps/crm-frontend/src/pages/Orders.tsx
@@ -1,0 +1,10 @@
+import CommentThread from '../components/common/comment-thread';
+
+export default function Orders() {
+  return (
+    <div>
+      <h1>Orders</h1>
+      <CommentThread entityId="orders" />
+    </div>
+  );
+}

--- a/apps/crm-frontend/src/pages/Settings.tsx
+++ b/apps/crm-frontend/src/pages/Settings.tsx
@@ -1,0 +1,10 @@
+import CommentThread from '../components/common/comment-thread';
+
+export default function Settings() {
+  return (
+    <div>
+      <h1>Settings</h1>
+      <CommentThread entityId="settings" />
+    </div>
+  );
+}

--- a/apps/crm-frontend/src/pages/Trades.tsx
+++ b/apps/crm-frontend/src/pages/Trades.tsx
@@ -1,0 +1,10 @@
+import CommentThread from '../components/common/comment-thread';
+
+export default function Trades() {
+  return (
+    <div>
+      <h1>Trades</h1>
+      <CommentThread entityId="trades" />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add generic comments API
- build comment thread component for listing, adding, editing and deleting
- wire comment threads into orders, trades, notifications and settings pages

## Testing
- `npm run build --workspace apps/crm-frontend`


------
https://chatgpt.com/codex/tasks/task_e_68a73c88a8688322bac5dc809d6c3a51