### PR TITLE
Add axios dependency and fix order API types

### DIFF
--- a/vite-template-typescript/package.json
+++ b/vite-template-typescript/package.json
@@ -49,6 +49,7 @@
     "@tiptap/react": "2.11.2",
     "@tiptap/starter-kit": "2.11.2",
     "@vitejs/plugin-react": "4.3.4",
+    "axios": "^1.11.0",
     "dayjs": "1.11.13",
     "embla-carousel": "8.5.2",
     "embla-carousel-react": "8.5.2",

--- a/vite-template-typescript/pnpm-lock.yaml
+++ b/vite-template-typescript/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: 4.3.4
         version: 4.3.4(vite@6.0.7(@types/node@22.10.5))
+      axios:
+        specifier: ^1.11.0
+        version: 1.11.0
       dayjs:
         specifier: 1.11.13
         version: 1.11.13
@@ -1848,6 +1851,9 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
+  axios@1.11.0:
+    resolution: {integrity: sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==}
+
   babel-jest@29.7.0:
     resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -2582,6 +2588,15 @@ packages:
   flatted@3.3.2:
     resolution: {integrity: sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==}
 
+  follow-redirects@1.15.11:
+    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   fontkit@2.0.4:
     resolution: {integrity: sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==}
 
@@ -2590,6 +2605,10 @@ packages:
 
   form-data@4.0.1:
     resolution: {integrity: sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==}
+    engines: {node: '>= 6'}
+
+  form-data@4.0.4:
+    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
     engines: {node: '>= 6'}
 
   format@0.2.2:
@@ -3780,6 +3799,9 @@ packages:
 
   protocol-buffers-schema@3.6.0:
     resolution: {integrity: sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   psl@1.15.0:
     resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
@@ -6472,6 +6494,14 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.0.0
 
+  axios@1.11.0:
+    dependencies:
+      follow-redirects: 1.15.11
+      form-data: 4.0.4
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+
   babel-jest@29.7.0(@babel/core@7.26.0):
     dependencies:
       '@babel/core': 7.26.0
@@ -7353,6 +7383,8 @@ snapshots:
 
   flatted@3.3.2: {}
 
+  follow-redirects@1.15.11: {}
+
   fontkit@2.0.4:
     dependencies:
       '@swc/helpers': 0.5.15
@@ -7373,6 +7405,14 @@ snapshots:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
+      mime-types: 2.1.35
+
+  form-data@4.0.4:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
       mime-types: 2.1.35
 
   format@0.2.2: {}
@@ -8973,6 +9013,8 @@ snapshots:
       prosemirror-transform: 1.10.2
 
   protocol-buffers-schema@3.6.0: {}
+
+  proxy-from-env@1.1.0: {}
 
   psl@1.15.0:
     dependencies:

--- a/vite-template-typescript/src/api/orders.ts
+++ b/vite-template-typescript/src/api/orders.ts
@@ -6,13 +6,17 @@ export interface OrderComment {
   createdAt: string;
 }
 
+interface RawOrder extends Omit<Order, "createdAt"> {
+  createdAt: string;
+}
+
 export async function getOpenOrders(): Promise<Order[]> {
   const res = await fetch("/order/open");
   if (!res.ok) {
     throw new Error("failed to fetch open orders");
   }
-  const data = await res.json();
-  return data.map((o: any) => ({ ...o, createdAt: new Date(o.createdAt) }));
+  const data: RawOrder[] = await res.json();
+  return data.map((o) => ({ ...o, createdAt: new Date(o.createdAt) }));
 }
 
 export async function getOrderHistory(): Promise<Order[]> {
@@ -20,8 +24,8 @@ export async function getOrderHistory(): Promise<Order[]> {
   if (!res.ok) {
     throw new Error("failed to fetch order history");
   }
-  const data = await res.json();
-  return data.map((o: any) => ({ ...o, createdAt: new Date(o.createdAt) }));
+  const data: RawOrder[] = await res.json();
+  return data.map((o) => ({ ...o, createdAt: new Date(o.createdAt) }));
 }
 
 export async function getOrderComments(orderId: string): Promise<OrderComment[]> {


### PR DESCRIPTION
## Summary
- install axios to resolve missing module during build
- type order API responses with RawOrder interface to eliminate `any`

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a75e1471348322a3e95a92de5e31a6