### PR TITLE
refactor: remove duplicate route definitions

### DIFF
--- a/apps/crm-server/src/auth/permissions.ts
+++ b/apps/crm-server/src/auth/permissions.ts
@@ -1,7 +1,6 @@
 export type Action =
   | 'dashboard.read'
   | 'users.read'
-
   | 'users.write'
   | 'wallets.read'
   | 'deposits.read'
@@ -22,12 +21,5 @@ export const rolePermissions: Record<string, Action[]> = {
   ],
   agent: ['dashboard.read', 'users.read', 'wallets.read', 'deposits.read', 'withdrawals.read'],
   support: ['dashboard.read', 'users.read']
-
-  | 'users.write';
-
-export const rolePermissions: Record<string, Action[]> = {
-  admin: ['dashboard.read', 'users.read', 'users.write'],
-  agent: ['dashboard.read', 'users.read'],
-  support: ['dashboard.read']
-
 };
+

--- a/apps/crm-server/src/routes/auth.ts
+++ b/apps/crm-server/src/routes/auth.ts
@@ -1,19 +1,10 @@
 
 import { Router, Request, Response, NextFunction } from 'express';
-
-
-import { Router, Request, Response, NextFunction } from 'express';
-
-import { Router } from 'express';
-
-
 import { query } from '../db/db.js';
 import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
 import { z } from 'zod';
 import type { JwtPayload } from '@alphatrade/shared';
-
-
 import { rateLimit } from '../middleware/rateLimit.js';
 import { HttpError } from '../middleware/error.js';
 
@@ -29,15 +20,7 @@ const loginSchema = z.object({
   password: z.string()
 });
 
-
 router.post('/login', rateLimit(5, 60000), asyncHandler(async (req: Request, res: Response) => {
-
-
-router.post('/login', rateLimit(5, 60000), asyncHandler(async (req: Request, res: Response) => {
-
-router.post('/login', async (req, res) => {
-
-
   const parsed = loginSchema.safeParse(req.body);
   if (!parsed.success) return res.status(400).json({ error: 'Invalid payload' });
   const { username, password } = parsed.data;
@@ -56,19 +39,6 @@ router.post('/login', async (req, res) => {
 }));
 
 router.get('/me', asyncHandler(async (req: Request, res: Response) => {
-
-
-  if (!admin) return res.status(401).json({ error: 'Invalid credentials' });
-  const match = await bcrypt.compare(password, admin.password);
-  if (!match) return res.status(401).json({ error: 'Invalid credentials' });
-  const payload: JwtPayload = { admin_id: admin.id, role: admin.role, perms: [] };
-  const token = jwt.sign(payload, process.env.JWT_SECRET!, { expiresIn: '1h' });
-  res.json({ token });
-});
-
-router.get('/me', async (req, res) => {
-
-
   const auth = req.headers.authorization;
   if (!auth) return res.status(401).end();
   const token = auth.split(' ')[1];
@@ -81,21 +51,9 @@ router.get('/me', async (req, res) => {
   } catch {
     res.status(401).end();
   }
-
 }));
 
 router.post('/logout', (req: Request, res: Response) => {
-
-
-}));
-
-router.post('/logout', (req: Request, res: Response) => {
-
-});
-
-router.post('/logout', (req, res) => {
-
-
   const auth = req.headers.authorization;
   if (auth) {
     const token = auth.split(' ')[1];

--- a/apps/crm-server/src/routes/dashboard.ts
+++ b/apps/crm-server/src/routes/dashboard.ts
@@ -1,4 +1,3 @@
-
 import { Router, Request, Response, NextFunction } from 'express';
 import { query, assertTableExists } from '../db/db.js';
 import * as sql from '../db/sql/dashboard.js';
@@ -21,27 +20,6 @@ router.get('/summary', asyncHandler(async (_req: Request, res: Response) => {
   summary.withdrawals = { ...withdrawals[0], ...w24[0] };
   if (await assertTableExists('user_daily_metrics')) {
     const metrics = await query<any>('SELECT SUM(yesterday_active) as yesterday, SUM(seven_day_active) as week FROM user_daily_metrics');
-
-
-import { Router } from 'express';
-import { query, assertTableExists } from '../db/db.js';
-
-const router = Router();
-
-router.get('/summary', async (_req, res) => {
-  const summary: any = {};
-  const orders = await query<any>('SELECT COUNT(*) as total, SUM(status="open") as open FROM orders');
-  const deposits = await query<any>('SELECT COUNT(*) as total, SUM(status="pending") as pending, SUM(status="successful") as successful FROM deposits');
-  const withdrawals = await query<any>('SELECT COUNT(*) as total, SUM(status="pending") as pending, SUM(status="approved") as approved, SUM(status="rejected") as rejected FROM withdrawals');
-  summary.orders = orders[0];
-  summary.deposits = deposits[0];
-  summary.withdrawals = withdrawals[0];
-  if (await assertTableExists('user_daily_metrics')) {
-    const metrics = await query<any>(
-      'SELECT SUM(yesterday_active) as yesterday, SUM(seven_day_active) as week FROM user_daily_metrics'
-    );
-
-
     summary.retention = metrics[0];
   } else {
     summary.retention = { yesterday: 0, week: 0 };
@@ -52,11 +30,5 @@ router.get('/summary', async (_req, res) => {
   summary.leads_new_7d = (await assertTableExists('leads')) ? (await query<any>(sql.leadsNew7d))[0].leads_new_7d : 0;
   res.json(summary);
 }));
-
-    
-  res.json(summary);
-});
-
-
 
 export default router;

--- a/apps/crm-server/src/routes/files.ts
+++ b/apps/crm-server/src/routes/files.ts
@@ -1,41 +1,18 @@
-
 import { Router, Request, Response, NextFunction } from 'express';
-
-import { Router, Request, Response, NextFunction } from 'express';
-
-import { Router } from 'express';
-
-
 import multer from 'multer';
 import path from 'path';
 import fs from 'fs';
 import { query } from '../db/db.js';
 
-
 const asyncHandler = (fn: any) => (req: Request, res: Response, next: NextFunction) =>
   Promise.resolve(fn(req, res, next)).catch(next);
-
-
-
-const asyncHandler = (fn: any) => (req: Request, res: Response, next: NextFunction) =>
-  Promise.resolve(fn(req, res, next)).catch(next);
-
-
 
 const router = Router();
 
 const storageRoot = process.env.FILE_STORAGE_ROOT!;
 const upload = multer({ dest: path.join(storageRoot, 'tmp') });
 
-
 router.post('/upload', upload.single('file'), asyncHandler(async (req: Request, res: Response) => {
-
-
-router.post('/upload', upload.single('file'), asyncHandler(async (req: Request, res: Response) => {
-
-router.post('/upload', upload.single('file'), async (req, res) => {
-
-
   if (!req.file) return res.status(400).json({ error: 'No file' });
   const timestamp = Date.now();
   const random = Math.random().toString(36).slice(2, 8);
@@ -47,15 +24,6 @@ router.post('/upload', upload.single('file'), async (req, res) => {
   await fs.promises.rename(req.file.path, dest);
   await query('INSERT INTO attachments (file, original_name) VALUES (?, ?)', [filename, req.file.originalname]);
   res.json({ file: filename, original: req.file.originalname });
-
 }));
-
-
-
-}));
-
-});
-
-
 
 export default router;


### PR DESCRIPTION
## Summary
- clean up permissions by removing leftover union fragment and duplicate rolePermissions block
- consolidate auth route imports and handlers into single definitions
- simplify dashboard and files routes by removing redundant imports and closing braces

## Testing
- `npm run build -w apps/crm-server` *(fails: Duplicate identifier errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68a76ff1a0d08322bc4719585503d6a5