### PR TITLE
Fix duplicate imports causing CRM server build failure

### DIFF
--- a/apps/crm-server/src/index.ts
+++ b/apps/crm-server/src/index.ts
@@ -1,4 +1,6 @@
 import express from 'express';
+import pino from 'pino';
+
 import authRoutes from './routes/auth.js';
 import fileRoutes from './routes/files.js';
 import dashboardRoutes from './routes/dashboard.js';
@@ -7,20 +9,10 @@ import walletsRoutes from './routes/wallets.js';
 import depositsRoutes from './routes/deposits.js';
 import withdrawalsRoutes from './routes/withdrawals.js';
 import internalRoutes from './routes/internal.js';
+
 import { requireAuth, requirePerm } from './middleware/auth.js';
 import { rateLimit } from './middleware/rateLimit.js';
 import { errorHandler } from './middleware/error.js';
-
-
-import usersRoutes from './routes/users.js';
-import { requireAuth, requirePerm } from './middleware/auth.js';
-import { rateLimit } from './middleware/rateLimit.js';
-import { errorHandler } from './middleware/error.js';
-
-import { requireAuth } from './middleware/auth.js';
-
-
-import pino from 'pino';
 
 const app = express();
 const logger = pino();
@@ -38,23 +30,10 @@ app.use('/internal', requireAuth, internalRoutes);
 
 app.use(errorHandler);
 
-
-
-app.use('/files', requireAuth, rateLimit(10, 60000), fileRoutes);
-app.use('/internal/dashboard', requireAuth, requirePerm('dashboard.read'), dashboardRoutes);
-app.use('/internal/users', requireAuth, usersRoutes);
-
-app.use(errorHandler);
-
-app.use('/files', requireAuth, fileRoutes);
-app.use('/internal/dashboard', requireAuth, dashboardRoutes);
-
 app.use((err: any, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
   logger.error({ err }, 'Unhandled error');
   res.status(500).json({ error: 'Internal error' });
 });
-
-
 
 const port = Number(process.env.PORT || 4000);
 app.listen(port, () => {

--- a/apps/crm-server/src/middleware/auth.ts
+++ b/apps/crm-server/src/middleware/auth.ts
@@ -4,12 +4,6 @@ import type { JwtPayload } from '@alphatrade/shared';
 
 import { rolePermissions, Action } from '../auth/permissions.js';
 
-
-
-import { rolePermissions, Action } from '../auth/permissions.js';
-
-
-
 export function requireAuth(req: Request, res: Response, next: NextFunction) {
   const auth = req.headers.authorization;
   if (!auth) return res.status(401).end();
@@ -17,11 +11,10 @@ export function requireAuth(req: Request, res: Response, next: NextFunction) {
     const token = auth.split(' ')[1];
     const payload = jwt.verify(token, process.env.JWT_SECRET!) as JwtPayload;
 
-    payload.perms = payload.perms && payload.perms.length ? payload.perms : rolePermissions[payload.role] || [];
-
-
-    payload.perms = payload.perms && payload.perms.length ? payload.perms : rolePermissions[payload.role] || [];
-
+    payload.perms =
+      payload.perms && payload.perms.length
+        ? payload.perms
+        : rolePermissions[payload.role] || [];
 
     (req as any).user = payload;
     next();
@@ -29,7 +22,6 @@ export function requireAuth(req: Request, res: Response, next: NextFunction) {
     res.status(401).end();
   }
 }
-
 
 export function requirePerm(action: Action) {
   return (req: Request, res: Response, next: NextFunction) => {


### PR DESCRIPTION
## Summary
- Remove duplicated imports and route registrations in CRM server entry point
- Clean up authentication middleware to prevent duplicate identifier errors

## Testing
- `npm run build -w apps/crm-frontend`
- `npm run build -w apps/crm-server`


------
https://chatgpt.com/codex/tasks/task_e_68a771ba7e988322aee187c55489ea28