### PR TITLE
feat: add p2p management endpoints

### DIFF
--- a/apps/crm-frontend/src/api/p2p.ts
+++ b/apps/crm-frontend/src/api/p2p.ts
@@ -18,3 +18,78 @@ export async function togglePaymentMethod(id: string, active: boolean) {
     body: JSON.stringify({ active })
   });
 }
+
+export interface P2PAd {
+  id: number;
+  type: number;
+  user_id: number;
+  asset_id: number;
+  fiat_id: number;
+  price: string;
+  minimum_amount: string;
+  maximum_amount: string;
+  status: number;
+}
+
+export async function listAds(): Promise<P2PAd[]> {
+  const res = await apiFetch('/internal/p2p/ads');
+  return res.data || [];
+}
+
+export async function createAd(data: Partial<P2PAd>) {
+  return apiFetch('/internal/p2p/ads', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+}
+
+export async function updateAd(id: number, data: Partial<P2PAd>) {
+  return apiFetch(`/internal/p2p/ads/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+}
+
+export async function toggleAd(id: number) {
+  return apiFetch(`/internal/p2p/ads/${id}/toggle`, { method: 'POST' });
+}
+
+export interface P2PTrade {
+  id: number;
+  uid: string;
+  type: number;
+  ad_id: number;
+  buyer_id: number;
+  seller_id: number;
+  asset_amount: string;
+  fiat_amount: string;
+  price: string;
+  status: number;
+}
+
+export async function listTrades(): Promise<P2PTrade[]> {
+  const res = await apiFetch('/internal/p2p/trades');
+  return res.data || [];
+}
+
+export async function getTrade(id: number) {
+  return apiFetch(`/internal/p2p/trades/${id}`);
+}
+
+export async function completeTrade(id: number) {
+  return apiFetch(`/internal/p2p/trades/${id}/complete`, { method: 'POST' });
+}
+
+export async function postTradeMessage(id: number, message: string) {
+  return apiFetch(`/internal/p2p/trades/${id}/message`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ message })
+  });
+}
+
+export async function resolveDispute(id: number) {
+  return apiFetch(`/internal/p2p/disputes/${id}/resolve`, { method: 'POST' });
+}

--- a/apps/crm-frontend/src/pages/admin/p2p/index.tsx
+++ b/apps/crm-frontend/src/pages/admin/p2p/index.tsx
@@ -1,6 +1,16 @@
 import { useEffect, useState } from 'react';
 import { Routes, Route } from 'react-router-dom';
-import { listPaymentMethods, togglePaymentMethod, PaymentMethod } from '../../../api/p2p';
+import {
+  listPaymentMethods,
+  togglePaymentMethod,
+  PaymentMethod,
+  listAds,
+  toggleAd,
+  P2PAd,
+  listTrades,
+  completeTrade,
+  P2PTrade
+} from '../../../api/p2p';
 
 function PaymentMethods() {
   const [methods, setMethods] = useState<PaymentMethod[]>([]);
@@ -28,12 +38,68 @@ function PaymentMethods() {
   );
 }
 
+function Ads() {
+  const [ads, setAds] = useState<P2PAd[]>([]);
+  useEffect(() => {
+    listAds().then(setAds);
+  }, []);
+
+  const toggle = async (ad: P2PAd) => {
+    await toggleAd(ad.id);
+    setAds(ads.map(a => a.id === ad.id ? { ...a, status: a.status ? 0 : 1 } : a));
+  };
+
+  return (
+    <div>
+      <h2>Ads</h2>
+      {ads.map(a => (
+        <div key={a.id} style={{ marginBottom: 8 }}>
+          Ad #{a.id} - {a.status ? 'Active' : 'Inactive'}
+          <button onClick={() => toggle(a)} style={{ marginLeft: 8 }}>
+            {a.status ? 'Disable' : 'Enable'}
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function Trades() {
+  const [trades, setTrades] = useState<P2PTrade[]>([]);
+  useEffect(() => {
+    listTrades().then(setTrades);
+  }, []);
+
+  const complete = async (t: P2PTrade) => {
+    await completeTrade(t.id);
+    setTrades(trades.map(tr => tr.id === t.id ? { ...tr, status: 1 } : tr));
+  };
+
+  return (
+    <div>
+      <h2>Trades</h2>
+      {trades.map(t => (
+        <div key={t.id} style={{ marginBottom: 8 }}>
+          Trade #{t.id} - Status {t.status}
+          {t.status !== 1 && (
+            <button onClick={() => complete(t)} style={{ marginLeft: 8 }}>
+              Complete
+            </button>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
 export default function P2PAdmin() {
   return (
     <div>
       <h1>P2P Admin</h1>
       <Routes>
         <Route path="payment-methods" element={<PaymentMethods />} />
+        <Route path="ads" element={<Ads />} />
+        <Route path="trades" element={<Trades />} />
         <Route path="*" element={<PaymentMethods />} />
       </Routes>
     </div>

--- a/apps/crm-server/src/db/sql/p2p.ts
+++ b/apps/crm-server/src/db/sql/p2p.ts
@@ -1,0 +1,17 @@
+export const listAds = `SELECT * FROM p2p_ads ORDER BY id DESC LIMIT ? OFFSET ?`;
+
+export const insertAd = `INSERT INTO p2p_ads (type, user_id, asset_id, fiat_id, payment_window_id, price_type, price, price_margin, minimum_amount, maximum_amount, payment_details, terms_of_trade, auto_replay_text, status) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`;
+
+export const updateAd = `UPDATE p2p_ads SET type = ?, user_id = ?, asset_id = ?, fiat_id = ?, payment_window_id = ?, price_type = ?, price = ?, price_margin = ?, minimum_amount = ?, maximum_amount = ?, payment_details = ?, terms_of_trade = ?, auto_replay_text = ?, status = ? WHERE id = ?`;
+
+export const toggleAd = `UPDATE p2p_ads SET status = IF(status = 1, 0, 1) WHERE id = ?`;
+
+export const listTrades = `SELECT * FROM p2p_trades ORDER BY id DESC LIMIT ? OFFSET ?`;
+
+export const getTrade = `SELECT * FROM p2p_trades WHERE id = ?`;
+
+export const completeTrade = `UPDATE p2p_trades SET status = 1 WHERE id = ?`;
+
+export const insertTradeMessage = `INSERT INTO p2p_trade_messages (trade_id, admin_id, message) VALUES (?, ?, ?)`;
+
+export const resolveDispute = `UPDATE p2p_trades SET status = 1 WHERE id = ?`;

--- a/apps/crm-server/src/routes/internal.ts
+++ b/apps/crm-server/src/routes/internal.ts
@@ -1,9 +1,25 @@
-import { Router } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
 import { requirePerm } from '../middleware/auth.js';
+import { pool, assertTableExists } from '../db/db.js';
+import { HttpError } from '../middleware/error.js';
+import {
+  listAds,
+  insertAd,
+  updateAd as sqlUpdateAd,
+  toggleAd,
+  listTrades,
+  getTrade,
+  completeTrade,
+  insertTradeMessage,
+  resolveDispute
+} from '../db/sql/p2p.js';
 
 const router = Router();
 
 const perm = (action: string) => requirePerm(action as any);
+
+const asyncHandler = (fn: any) => (req: Request, res: Response, next: NextFunction) =>
+  Promise.resolve(fn(req, res, next)).catch(next);
 
 function notImplemented(_req: any, res: any) {
   res.status(501).json({ error: 'not implemented' });
@@ -23,15 +39,132 @@ router.get('/binary/trades', perm('binary.trades.read'), notImplemented);
 router.post('/binary/trades/:id/refund', perm('binary.trades.write'), notImplemented);
 
 // P2P
-router.get('/p2p/ads', perm('p2p.read'), notImplemented);
-router.post('/p2p/ads', perm('p2p.write'), notImplemented);
-router.put('/p2p/ads/:id', perm('p2p.write'), notImplemented);
-router.post('/p2p/ads/:id/toggle', perm('p2p.write'), notImplemented);
-router.get('/p2p/trades', perm('p2p.read'), notImplemented);
-router.get('/p2p/trades/:id', perm('p2p.read'), notImplemented);
-router.post('/p2p/trades/:id/complete', perm('p2p.write'), notImplemented);
-router.post('/p2p/trades/:id/message', perm('p2p.write'), notImplemented);
-router.post('/p2p/disputes/:id/resolve', perm('p2p.write'), notImplemented);
+router.get('/p2p/ads', perm('p2p.read'), asyncHandler(async (req: Request, res: Response) => {
+  if (!(await assertTableExists('p2p_ads'))) return res.json({ data: [] });
+  const { limit = '20', offset = '0' } = req.query;
+  const [rows] = await (pool.query as any)(listAds, [Number(limit), Number(offset)]);
+  res.json({ data: rows });
+}));
+
+router.post('/p2p/ads', perm('p2p.write'), asyncHandler(async (req: Request, res: Response) => {
+  if (!(await assertTableExists('p2p_ads'))) throw new HttpError(501, 'not_supported', 'not supported');
+  const {
+    type,
+    user_id,
+    asset_id,
+    fiat_id,
+    payment_window_id,
+    price_type,
+    price,
+    price_margin,
+    minimum_amount,
+    maximum_amount,
+    payment_details = null,
+    terms_of_trade = null,
+    auto_replay_text = null,
+    status = 1
+  } = req.body;
+  const [result] = await (pool.query as any)(insertAd, [
+    type,
+    user_id,
+    asset_id,
+    fiat_id,
+    payment_window_id,
+    price_type,
+    price,
+    price_margin,
+    minimum_amount,
+    maximum_amount,
+    payment_details,
+    terms_of_trade,
+    auto_replay_text,
+    status
+  ]);
+  res.json({ id: (result as any).insertId });
+}));
+
+router.put('/p2p/ads/:id', perm('p2p.write'), asyncHandler(async (req: Request, res: Response) => {
+  if (!(await assertTableExists('p2p_ads'))) throw new HttpError(501, 'not_supported', 'not supported');
+  const id = Number(req.params.id);
+  const {
+    type,
+    user_id,
+    asset_id,
+    fiat_id,
+    payment_window_id,
+    price_type,
+    price,
+    price_margin,
+    minimum_amount,
+    maximum_amount,
+    payment_details = null,
+    terms_of_trade = null,
+    auto_replay_text = null,
+    status = 1
+  } = req.body;
+  await (pool.query as any)(sqlUpdateAd, [
+    type,
+    user_id,
+    asset_id,
+    fiat_id,
+    payment_window_id,
+    price_type,
+    price,
+    price_margin,
+    minimum_amount,
+    maximum_amount,
+    payment_details,
+    terms_of_trade,
+    auto_replay_text,
+    status,
+    id
+  ]);
+  res.json({ ok: true });
+}));
+
+router.post('/p2p/ads/:id/toggle', perm('p2p.write'), asyncHandler(async (req: Request, res: Response) => {
+  if (!(await assertTableExists('p2p_ads'))) throw new HttpError(501, 'not_supported', 'not supported');
+  const id = Number(req.params.id);
+  await (pool.query as any)(toggleAd, [id]);
+  res.json({ ok: true });
+}));
+
+router.get('/p2p/trades', perm('p2p.read'), asyncHandler(async (req: Request, res: Response) => {
+  if (!(await assertTableExists('p2p_trades'))) return res.json({ data: [] });
+  const { limit = '20', offset = '0' } = req.query;
+  const [rows] = await (pool.query as any)(listTrades, [Number(limit), Number(offset)]);
+  res.json({ data: rows });
+}));
+
+router.get('/p2p/trades/:id', perm('p2p.read'), asyncHandler(async (req: Request, res: Response) => {
+  if (!(await assertTableExists('p2p_trades'))) throw new HttpError(404, 'not_found', 'not found');
+  const id = Number(req.params.id);
+  const [rows] = await (pool.query as any)(getTrade, [id]);
+  res.json({ data: rows[0] || null });
+}));
+
+router.post('/p2p/trades/:id/complete', perm('p2p.write'), asyncHandler(async (req: Request, res: Response) => {
+  if (!(await assertTableExists('p2p_trades'))) throw new HttpError(501, 'not_supported', 'not supported');
+  const id = Number(req.params.id);
+  await (pool.query as any)(completeTrade, [id]);
+  res.json({ ok: true });
+}));
+
+router.post('/p2p/trades/:id/message', perm('p2p.write'), asyncHandler(async (req: Request, res: Response) => {
+  if (!(await assertTableExists('p2p_trade_messages'))) throw new HttpError(501, 'not_supported', 'not supported');
+  const tradeId = Number(req.params.id);
+  const { message = '' } = req.body;
+  const adminId = (req as any).user?.id || 0;
+  await (pool.query as any)(insertTradeMessage, [tradeId, adminId, message]);
+  res.json({ ok: true });
+}));
+
+router.post('/p2p/disputes/:id/resolve', perm('p2p.write'), asyncHandler(async (req: Request, res: Response) => {
+  if (!(await assertTableExists('p2p_trades'))) throw new HttpError(501, 'not_supported', 'not supported');
+  const id = Number(req.params.id);
+  await (pool.query as any)(resolveDispute, [id]);
+  res.json({ ok: true });
+}));
 
 // Support
 router.get('/support/tickets', perm('support.read'), notImplemented);


### PR DESCRIPTION
## Summary
- implement internal p2p ads/trades endpoints
- add SQL queries for p2p data
- expose p2p admin pages and client helpers

## Testing
- `npm run build -w apps/crm-server`
- `npm run build -w apps/crm-frontend`


------
https://chatgpt.com/codex/tasks/task_e_68a777e6c56883229b3b365645403122