### PR TITLE
Add support ticket management

### DIFF
--- a/apps/crm-frontend/src/App.tsx
+++ b/apps/crm-frontend/src/App.tsx
@@ -20,6 +20,8 @@ import SystemInfo from './pages/admin/SystemInfo';
 
 import BinaryTrades from './pages/admin/binary-trades';
 import P2PAdmin from './pages/admin/p2p';
+import SupportTickets from './pages/support/Tickets';
+import SupportTicket from './pages/support/Ticket';
 
 import AdminCurrencies from './pages/admin/currencies';
 import AdminMarkets from './pages/admin/markets';
@@ -61,7 +63,8 @@ export default function App() {
       <Route path="/trading/futures" element={token ? <Placeholder title="Trading Futures" /> : <Navigate to="/login" />} />
       <Route path="/admin/binary-trades/*" element={token ? <BinaryTrades /> : <Navigate to="/login" />} />
       <Route path="/admin/p2p/*" element={token ? <P2PAdmin /> : <Navigate to="/login" />} />
-      <Route path="/support" element={token ? <Placeholder title="Support" /> : <Navigate to="/login" />} />
+      <Route path="/support" element={token ? <SupportTickets /> : <Navigate to="/login" />} />
+      <Route path="/support/:id" element={token ? <SupportTicket /> : <Navigate to="/login" />} />
       <Route path="/crm/leads" element={token ? <Placeholder title="CRM Leads" /> : <Navigate to="/login" />} />
       <Route path="/crm/contacts" element={token ? <Placeholder title="CRM Contacts" /> : <Navigate to="/login" />} />
       <Route path="/crm/opportunities" element={token ? <Placeholder title="CRM Opportunities" /> : <Navigate to="/login" />} />

--- a/apps/crm-frontend/src/pages/support/Ticket.tsx
+++ b/apps/crm-frontend/src/pages/support/Ticket.tsx
@@ -1,0 +1,41 @@
+import { useState } from 'react';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { useParams } from 'react-router-dom';
+import { apiFetch } from '../../api/client';
+
+export default function Ticket() {
+  const { id } = useParams();
+  const { data, refetch } = useQuery({
+    queryKey: ['support', 'ticket', id],
+    queryFn: () => apiFetch(`/internal/support/tickets/${id}`),
+    enabled: !!id,
+  });
+  const [message, setMessage] = useState('');
+  const mutation = useMutation({
+    mutationFn: () =>
+      apiFetch(`/internal/support/tickets/${id}/reply`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message }),
+      }),
+    onSuccess: () => {
+      setMessage('');
+      refetch();
+    },
+  });
+  return (
+    <div>
+      <h1>Ticket {id}</h1>
+      <pre>{JSON.stringify(data, null, 2)}</pre>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          mutation.mutate();
+        }}
+      >
+        <textarea value={message} onChange={(e) => setMessage(e.target.value)} />
+        <button type="submit">Reply</button>
+      </form>
+    </div>
+  );
+}

--- a/apps/crm-frontend/src/pages/support/Tickets.tsx
+++ b/apps/crm-frontend/src/pages/support/Tickets.tsx
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiFetch } from '../../api/client';
+
+export default function Tickets() {
+  const { data } = useQuery({ queryKey: ['support', 'tickets'], queryFn: () => apiFetch('/internal/support/tickets') });
+  return (
+    <div>
+      <h1>Support Tickets</h1>
+      <pre>{JSON.stringify(data, null, 2)}</pre>
+    </div>
+  );
+}

--- a/apps/crm-server/src/auth/permissions.ts
+++ b/apps/crm-server/src/auth/permissions.ts
@@ -6,7 +6,9 @@ export type Action =
   | 'deposits.read'
   | 'deposits.write'
   | 'withdrawals.read'
-  | 'withdrawals.write';
+  | 'withdrawals.write'
+  | 'support.read'
+  | 'support.write';
 
 export const rolePermissions: Record<string, Action[]> = {
   admin: [
@@ -17,9 +19,11 @@ export const rolePermissions: Record<string, Action[]> = {
     'deposits.read',
     'deposits.write',
     'withdrawals.read',
-    'withdrawals.write'
+    'withdrawals.write',
+    'support.read',
+    'support.write'
   ],
   agent: ['dashboard.read', 'users.read', 'wallets.read', 'deposits.read', 'withdrawals.read'],
-  support: ['dashboard.read', 'users.read']
+  support: ['dashboard.read', 'users.read', 'support.read', 'support.write']
 };
 

--- a/apps/crm-server/src/db/sql/support.ts
+++ b/apps/crm-server/src/db/sql/support.ts
@@ -1,0 +1,50 @@
+export const createTicketsTable = `
+  CREATE TABLE IF NOT EXISTS support_tickets (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    subject VARCHAR(255) NOT NULL,
+    status ENUM('open','closed') DEFAULT 'open',
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    closed_at DATETIME NULL
+  )
+`;
+
+export const createMessagesTable = `
+  CREATE TABLE IF NOT EXISTS support_messages (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    ticket_id INT NOT NULL,
+    sender ENUM('user','admin') NOT NULL,
+    message TEXT NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+  )
+`;
+
+export const listTickets = `
+  SELECT id, user_id, subject, status, created_at, closed_at
+  FROM support_tickets
+  ORDER BY id DESC
+  LIMIT ? OFFSET ?
+`;
+
+export const getTicket = `
+  SELECT id, user_id, subject, status, created_at, closed_at
+  FROM support_tickets
+  WHERE id = ?
+`;
+
+export const getMessages = `
+  SELECT id, ticket_id, sender, message, created_at
+  FROM support_messages
+  WHERE ticket_id = ?
+  ORDER BY id ASC
+`;
+
+export const insertMessage = `
+  INSERT INTO support_messages (ticket_id, sender, message)
+  VALUES (?, ?, ?)
+`;
+
+export const closeTicket = `
+  UPDATE support_tickets SET status='closed', closed_at=NOW()
+  WHERE id = ?
+`;

--- a/apps/crm-server/src/index.ts
+++ b/apps/crm-server/src/index.ts
@@ -8,6 +8,7 @@ import usersRoutes from './routes/users.js';
 import walletsRoutes from './routes/wallets.js';
 import depositsRoutes from './routes/deposits.js';
 import withdrawalsRoutes from './routes/withdrawals.js';
+import supportRoutes from './routes/support.js';
 import internalRoutes from './routes/internal.js';
 
 import { requireAuth, requirePerm } from './middleware/auth.js';
@@ -26,6 +27,7 @@ app.use('/internal/users', requireAuth, usersRoutes);
 app.use('/internal/wallets', requireAuth, walletsRoutes);
 app.use('/internal/deposits', requireAuth, depositsRoutes);
 app.use('/internal/withdrawals', requireAuth, withdrawalsRoutes);
+app.use('/internal/support', requireAuth, supportRoutes);
 app.use('/internal', requireAuth, internalRoutes);
 
 app.use(errorHandler);

--- a/apps/crm-server/src/routes/internal.ts
+++ b/apps/crm-server/src/routes/internal.ts
@@ -33,12 +33,6 @@ router.post('/p2p/trades/:id/complete', perm('p2p.write'), notImplemented);
 router.post('/p2p/trades/:id/message', perm('p2p.write'), notImplemented);
 router.post('/p2p/disputes/:id/resolve', perm('p2p.write'), notImplemented);
 
-// Support
-router.get('/support/tickets', perm('support.read'), notImplemented);
-router.get('/support/tickets/:id', perm('support.read'), notImplemented);
-router.post('/support/tickets/:id/reply', perm('support.write'), notImplemented);
-router.post('/support/tickets/:id/close', perm('support.write'), notImplemented);
-
 // CRM
 router.get('/crm/leads', perm('crm.read'), notImplemented);
 router.post('/crm/leads', perm('crm.write'), notImplemented);

--- a/apps/crm-server/src/routes/support.ts
+++ b/apps/crm-server/src/routes/support.ts
@@ -1,0 +1,43 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { pool, assertTableExists } from '../db/db.js';
+import * as sql from '../db/sql/support.js';
+import { requirePerm } from '../middleware/auth.js';
+import { HttpError } from '../middleware/error.js';
+
+const router = Router();
+const asyncHandler = (fn: any) => (req: Request, res: Response, next: NextFunction) =>
+  Promise.resolve(fn(req, res, next)).catch(next);
+
+router.get('/tickets', requirePerm('support.read'), asyncHandler(async (req: Request, res: Response) => {
+  if (!(await assertTableExists('support_tickets'))) return res.json({ data: [] });
+  const { limit = '20', offset = '0' } = req.query;
+  const [rows] = await (pool.query as any)(sql.listTickets, [Number(limit), Number(offset)]);
+  res.json({ data: rows });
+}));
+
+router.get('/tickets/:id', requirePerm('support.read'), asyncHandler(async (req: Request, res: Response) => {
+  if (!(await assertTableExists('support_tickets'))) throw new HttpError(404, 'not_found', 'ticket not found');
+  const id = Number(req.params.id);
+  const [tickets] = await (pool.query as any)(sql.getTicket, [id]);
+  if ((tickets as any).length === 0) throw new HttpError(404, 'not_found', 'ticket not found');
+  const [messages] = await (pool.query as any)(sql.getMessages, [id]);
+  res.json({ ticket: (tickets as any)[0], messages });
+}));
+
+router.post('/tickets/:id/reply', requirePerm('support.write'), asyncHandler(async (req: Request, res: Response) => {
+  if (!(await assertTableExists('support_tickets'))) throw new HttpError(501, 'not_supported', 'not supported');
+  const id = Number(req.params.id);
+  const { message = '' } = req.body;
+  if (!message) throw new HttpError(400, 'bad_request', 'message required');
+  await (pool.query as any)(sql.insertMessage, [id, 'admin', message]);
+  res.json({ ok: true });
+}));
+
+router.post('/tickets/:id/close', requirePerm('support.write'), asyncHandler(async (req: Request, res: Response) => {
+  if (!(await assertTableExists('support_tickets'))) throw new HttpError(501, 'not_supported', 'not supported');
+  const id = Number(req.params.id);
+  await (pool.query as any)(sql.closeTicket, [id]);
+  res.json({ ok: true });
+}));
+
+export default router;


### PR DESCRIPTION
## Summary
- define SQL schema and queries for support tickets
- add Express routes for listing, replying to, and closing tickets
- create React pages for viewing tickets and responding

## Testing
- `npm run build -w apps/crm-server`
- `npm run build -w apps/crm-frontend`


------
https://chatgpt.com/codex/tasks/task_e_68a777eabe1483229fe8da2d6a4f27d7