### PR TITLE
feat: add CRM endpoints and pages

### DIFF
--- a/apps/crm-frontend/src/App.tsx
+++ b/apps/crm-frontend/src/App.tsx
@@ -24,6 +24,12 @@ import P2PAdmin from './pages/admin/p2p';
 import AdminCurrencies from './pages/admin/currencies';
 import AdminMarkets from './pages/admin/markets';
 
+import Leads from './pages/crm/Leads';
+import Contacts from './pages/crm/Contacts';
+import Opportunities from './pages/crm/Opportunities';
+import Tasks from './pages/crm/Tasks';
+import Notes from './pages/crm/Notes';
+import Chat from './pages/crm/Chat';
 
 export default function App() {
   const [token, setToken] = useState<string | null>(localStorage.getItem('token'));
@@ -62,12 +68,12 @@ export default function App() {
       <Route path="/admin/binary-trades/*" element={token ? <BinaryTrades /> : <Navigate to="/login" />} />
       <Route path="/admin/p2p/*" element={token ? <P2PAdmin /> : <Navigate to="/login" />} />
       <Route path="/support" element={token ? <Placeholder title="Support" /> : <Navigate to="/login" />} />
-      <Route path="/crm/leads" element={token ? <Placeholder title="CRM Leads" /> : <Navigate to="/login" />} />
-      <Route path="/crm/contacts" element={token ? <Placeholder title="CRM Contacts" /> : <Navigate to="/login" />} />
-      <Route path="/crm/opportunities" element={token ? <Placeholder title="CRM Opportunities" /> : <Navigate to="/login" />} />
-      <Route path="/crm/tasks" element={token ? <Placeholder title="CRM Tasks" /> : <Navigate to="/login" />} />
-      <Route path="/crm/notes" element={token ? <Placeholder title="CRM Notes" /> : <Navigate to="/login" />} />
-      <Route path="/crm/chat" element={token ? <Placeholder title="CRM Staff Chat" /> : <Navigate to="/login" />} />
+      <Route path="/crm/leads" element={token ? <Leads /> : <Navigate to="/login" />} />
+      <Route path="/crm/contacts" element={token ? <Contacts /> : <Navigate to="/login" />} />
+      <Route path="/crm/opportunities" element={token ? <Opportunities /> : <Navigate to="/login" />} />
+      <Route path="/crm/tasks" element={token ? <Tasks /> : <Navigate to="/login" />} />
+      <Route path="/crm/notes" element={token ? <Notes /> : <Navigate to="/login" />} />
+      <Route path="/crm/chat" element={token ? <Chat /> : <Navigate to="/login" />} />
       <Route path="/reports" element={token ? <Placeholder title="Reports" /> : <Navigate to="/login" />} />
 
       <Route path="/settings" element={token ? <Settings /> : <Navigate to="/login" />} />

--- a/apps/crm-frontend/src/pages/crm/Chat.tsx
+++ b/apps/crm-frontend/src/pages/crm/Chat.tsx
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiFetch } from '../../api/client';
+
+export default function Chat() {
+  const { data } = useQuery({ queryKey: ['crm','chat'], queryFn: () => apiFetch('/internal/crm/chat') });
+  return (
+    <div>
+      <h1>CRM Staff Chat</h1>
+      <pre>{JSON.stringify(data, null, 2)}</pre>
+    </div>
+  );
+}

--- a/apps/crm-frontend/src/pages/crm/Contacts.tsx
+++ b/apps/crm-frontend/src/pages/crm/Contacts.tsx
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiFetch } from '../../api/client';
+
+export default function Contacts() {
+  const { data } = useQuery({ queryKey: ['crm','contacts'], queryFn: () => apiFetch('/internal/crm/contacts') });
+  return (
+    <div>
+      <h1>CRM Contacts</h1>
+      <pre>{JSON.stringify(data, null, 2)}</pre>
+    </div>
+  );
+}

--- a/apps/crm-frontend/src/pages/crm/Leads.tsx
+++ b/apps/crm-frontend/src/pages/crm/Leads.tsx
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiFetch } from '../../api/client';
+
+export default function Leads() {
+  const { data } = useQuery({ queryKey: ['crm','leads'], queryFn: () => apiFetch('/internal/crm/leads') });
+  return (
+    <div>
+      <h1>CRM Leads</h1>
+      <pre>{JSON.stringify(data, null, 2)}</pre>
+    </div>
+  );
+}

--- a/apps/crm-frontend/src/pages/crm/Notes.tsx
+++ b/apps/crm-frontend/src/pages/crm/Notes.tsx
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiFetch } from '../../api/client';
+
+export default function Notes() {
+  const { data } = useQuery({ queryKey: ['crm','notes'], queryFn: () => apiFetch('/internal/crm/notes') });
+  return (
+    <div>
+      <h1>CRM Notes</h1>
+      <pre>{JSON.stringify(data, null, 2)}</pre>
+    </div>
+  );
+}

--- a/apps/crm-frontend/src/pages/crm/Opportunities.tsx
+++ b/apps/crm-frontend/src/pages/crm/Opportunities.tsx
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiFetch } from '../../api/client';
+
+export default function Opportunities() {
+  const { data } = useQuery({ queryKey: ['crm','opportunities'], queryFn: () => apiFetch('/internal/crm/opportunities') });
+  return (
+    <div>
+      <h1>CRM Opportunities</h1>
+      <pre>{JSON.stringify(data, null, 2)}</pre>
+    </div>
+  );
+}

--- a/apps/crm-frontend/src/pages/crm/Tasks.tsx
+++ b/apps/crm-frontend/src/pages/crm/Tasks.tsx
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiFetch } from '../../api/client';
+
+export default function Tasks() {
+  const { data } = useQuery({ queryKey: ['crm','tasks'], queryFn: () => apiFetch('/internal/crm/tasks') });
+  return (
+    <div>
+      <h1>CRM Tasks</h1>
+      <pre>{JSON.stringify(data, null, 2)}</pre>
+    </div>
+  );
+}

--- a/apps/crm-server/src/auth/permissions.ts
+++ b/apps/crm-server/src/auth/permissions.ts
@@ -6,7 +6,9 @@ export type Action =
   | 'deposits.read'
   | 'deposits.write'
   | 'withdrawals.read'
-  | 'withdrawals.write';
+  | 'withdrawals.write'
+  | 'crm.read'
+  | 'crm.write';
 
 export const rolePermissions: Record<string, Action[]> = {
   admin: [
@@ -17,9 +19,19 @@ export const rolePermissions: Record<string, Action[]> = {
     'deposits.read',
     'deposits.write',
     'withdrawals.read',
-    'withdrawals.write'
+    'withdrawals.write',
+    'crm.read',
+    'crm.write'
   ],
-  agent: ['dashboard.read', 'users.read', 'wallets.read', 'deposits.read', 'withdrawals.read'],
+  agent: [
+    'dashboard.read',
+    'users.read',
+    'wallets.read',
+    'deposits.read',
+    'withdrawals.read',
+    'crm.read',
+    'crm.write'
+  ],
   support: ['dashboard.read', 'users.read']
 };
 

--- a/apps/crm-server/src/db/sql/crm.ts
+++ b/apps/crm-server/src/db/sql/crm.ts
@@ -1,0 +1,20 @@
+export const listLeads = `SELECT * FROM crm_leads ORDER BY id DESC LIMIT ? OFFSET ?`;
+export const insertLead = `INSERT INTO crm_leads (name, email, status) VALUES (?, ?, ?)`;
+export const updateLead = `UPDATE crm_leads SET name = ?, email = ?, status = ? WHERE id = ?`;
+
+export const listContacts = `SELECT * FROM crm_contacts ORDER BY id DESC LIMIT ? OFFSET ?`;
+export const insertContact = `INSERT INTO crm_contacts (name, email, phone) VALUES (?, ?, ?)`;
+
+export const listOpportunities = `SELECT * FROM crm_opportunities ORDER BY id DESC LIMIT ? OFFSET ?`;
+export const insertOpportunity = `INSERT INTO crm_opportunities (name, value, stage) VALUES (?, ?, ?)`;
+export const updateOpportunity = `UPDATE crm_opportunities SET name = ?, value = ?, stage = ? WHERE id = ?`;
+export const updateOpportunityStage = `UPDATE crm_opportunities SET stage = ? WHERE id = ?`;
+
+export const listTasks = `SELECT * FROM crm_tasks ORDER BY id DESC LIMIT ? OFFSET ?`;
+export const insertTask = `INSERT INTO crm_tasks (title, due_date, status) VALUES (?, ?, ?)`;
+
+export const listNotes = `SELECT * FROM crm_notes ORDER BY id DESC LIMIT ? OFFSET ?`;
+export const insertNote = `INSERT INTO crm_notes (entity, entity_id, note) VALUES (?, ?, ?)`;
+
+export const listChat = `SELECT * FROM crm_chat ORDER BY id DESC LIMIT ? OFFSET ?`;
+export const insertChat = `INSERT INTO crm_chat (sender_id, message) VALUES (?, ?)`;

--- a/apps/crm-server/src/routes/internal.ts
+++ b/apps/crm-server/src/routes/internal.ts
@@ -1,9 +1,30 @@
-import { Router } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
 import { requirePerm } from '../middleware/auth.js';
+import { query } from '../db/db.js';
+import {
+  listLeads,
+  insertLead,
+  updateLead,
+  listContacts,
+  insertContact,
+  listOpportunities,
+  insertOpportunity,
+  updateOpportunity,
+  updateOpportunityStage,
+  listTasks,
+  insertTask,
+  listNotes,
+  insertNote,
+  listChat,
+  insertChat
+} from '../db/sql/crm.js';
 
 const router = Router();
 
 const perm = (action: string) => requirePerm(action as any);
+
+const asyncHandler = (fn: any) => (req: Request, res: Response, next: NextFunction) =>
+  Promise.resolve(fn(req, res, next)).catch(next);
 
 function notImplemented(_req: any, res: any) {
   res.status(501).json({ error: 'not implemented' });
@@ -40,21 +61,98 @@ router.post('/support/tickets/:id/reply', perm('support.write'), notImplemented)
 router.post('/support/tickets/:id/close', perm('support.write'), notImplemented);
 
 // CRM
-router.get('/crm/leads', perm('crm.read'), notImplemented);
-router.post('/crm/leads', perm('crm.write'), notImplemented);
-router.put('/crm/leads/:id', perm('crm.write'), notImplemented);
-router.get('/crm/contacts', perm('crm.read'), notImplemented);
-router.post('/crm/contacts', perm('crm.write'), notImplemented);
-router.get('/crm/opportunities', perm('crm.read'), notImplemented);
-router.post('/crm/opportunities', perm('crm.write'), notImplemented);
-router.put('/crm/opportunities/:id', perm('crm.write'), notImplemented);
-router.post('/crm/opportunities/:id/stage', perm('crm.write'), notImplemented);
-router.get('/crm/tasks', perm('crm.read'), notImplemented);
-router.post('/crm/tasks', perm('crm.write'), notImplemented);
-router.get('/crm/notes', perm('crm.read'), notImplemented);
-router.post('/crm/notes', perm('crm.write'), notImplemented);
-router.get('/crm/chat', perm('crm.read'), notImplemented);
-router.post('/crm/chat', perm('crm.write'), notImplemented);
+router.get('/crm/leads', perm('crm.read'), asyncHandler(async (req: Request, res: Response) => {
+  const { limit = '20', offset = '0' } = req.query;
+  const rows = await query(listLeads, [Number(limit), Number(offset)]);
+  res.json({ data: rows });
+}));
+
+router.post('/crm/leads', perm('crm.write'), asyncHandler(async (req: Request, res: Response) => {
+  const { name, email, status } = req.body;
+  await query(insertLead, [name, email, status]);
+  res.json({ ok: true });
+}));
+
+router.put('/crm/leads/:id', perm('crm.write'), asyncHandler(async (req: Request, res: Response) => {
+  const id = Number(req.params.id);
+  const { name, email, status } = req.body;
+  await query(updateLead, [name, email, status, id]);
+  res.json({ ok: true });
+}));
+
+router.get('/crm/contacts', perm('crm.read'), asyncHandler(async (req: Request, res: Response) => {
+  const { limit = '20', offset = '0' } = req.query;
+  const rows = await query(listContacts, [Number(limit), Number(offset)]);
+  res.json({ data: rows });
+}));
+
+router.post('/crm/contacts', perm('crm.write'), asyncHandler(async (req: Request, res: Response) => {
+  const { name, email, phone } = req.body;
+  await query(insertContact, [name, email, phone]);
+  res.json({ ok: true });
+}));
+
+router.get('/crm/opportunities', perm('crm.read'), asyncHandler(async (req: Request, res: Response) => {
+  const { limit = '20', offset = '0' } = req.query;
+  const rows = await query(listOpportunities, [Number(limit), Number(offset)]);
+  res.json({ data: rows });
+}));
+
+router.post('/crm/opportunities', perm('crm.write'), asyncHandler(async (req: Request, res: Response) => {
+  const { name, value, stage } = req.body;
+  await query(insertOpportunity, [name, value, stage]);
+  res.json({ ok: true });
+}));
+
+router.put('/crm/opportunities/:id', perm('crm.write'), asyncHandler(async (req: Request, res: Response) => {
+  const id = Number(req.params.id);
+  const { name, value, stage } = req.body;
+  await query(updateOpportunity, [name, value, stage, id]);
+  res.json({ ok: true });
+}));
+
+router.post('/crm/opportunities/:id/stage', perm('crm.write'), asyncHandler(async (req: Request, res: Response) => {
+  const id = Number(req.params.id);
+  const { stage } = req.body;
+  await query(updateOpportunityStage, [stage, id]);
+  res.json({ ok: true });
+}));
+
+router.get('/crm/tasks', perm('crm.read'), asyncHandler(async (req: Request, res: Response) => {
+  const { limit = '20', offset = '0' } = req.query;
+  const rows = await query(listTasks, [Number(limit), Number(offset)]);
+  res.json({ data: rows });
+}));
+
+router.post('/crm/tasks', perm('crm.write'), asyncHandler(async (req: Request, res: Response) => {
+  const { title, due_date, status } = req.body;
+  await query(insertTask, [title, due_date, status]);
+  res.json({ ok: true });
+}));
+
+router.get('/crm/notes', perm('crm.read'), asyncHandler(async (req: Request, res: Response) => {
+  const { limit = '20', offset = '0' } = req.query;
+  const rows = await query(listNotes, [Number(limit), Number(offset)]);
+  res.json({ data: rows });
+}));
+
+router.post('/crm/notes', perm('crm.write'), asyncHandler(async (req: Request, res: Response) => {
+  const { entity, entity_id, note } = req.body;
+  await query(insertNote, [entity, entity_id, note]);
+  res.json({ ok: true });
+}));
+
+router.get('/crm/chat', perm('crm.read'), asyncHandler(async (req: Request, res: Response) => {
+  const { limit = '20', offset = '0' } = req.query;
+  const rows = await query(listChat, [Number(limit), Number(offset)]);
+  res.json({ data: rows });
+}));
+
+router.post('/crm/chat', perm('crm.write'), asyncHandler(async (req: Request, res: Response) => {
+  const { sender_id, message } = req.body;
+  await query(insertChat, [sender_id, message]);
+  res.json({ ok: true });
+}));
 
 // Reports
 router.get('/reports/transactions', perm('reports.read'), notImplemented);


### PR DESCRIPTION
## Summary
- implement SQL helpers for CRM entities
- expose CRUD endpoints for leads, contacts, opportunities, tasks, notes and chat
- add crm.read/crm.write permissions and basic React pages

## Testing
- `npm run build -w apps/crm-server`
- `npm run build -w apps/crm-frontend`


------
https://chatgpt.com/codex/tasks/task_e_68a777f2522c8322abdd8ebda9e3f410