### PR TITLE
feat: add comments API

### DIFF
--- a/apps/crm-frontend/src/api/comments.ts
+++ b/apps/crm-frontend/src/api/comments.ts
@@ -3,6 +3,7 @@ import { apiFetch } from './client';
 export interface Comment {
   id: string;
   content: string;
+  created_at?: string;
 }
 
 export function listComments(entityId: string): Promise<Comment[]> {
@@ -28,5 +29,5 @@ export function updateComment(entityId: string, id: string, content: string): Pr
 export function deleteComment(entityId: string, id: string): Promise<void> {
   return apiFetch(`/api/comments/${id}?entityId=${encodeURIComponent(entityId)}`, {
     method: 'DELETE',
-  });
+  }).then(() => {});
 }

--- a/apps/crm-frontend/src/components/admin/comment-panel.tsx
+++ b/apps/crm-frontend/src/components/admin/comment-panel.tsx
@@ -1,28 +1,16 @@
 import { useState } from 'react';
 import { useMutation, useQuery } from '@tanstack/react-query';
-import { apiFetch } from '../../api/client';
-
-interface Comment {
-  id?: string;
-  text: string;
-  createdAt?: string;
-}
+import { listComments, addComment, Comment } from '../../api/comments';
 
 export default function CommentPanel({ resource }: { resource: string }) {
   const [text, setText] = useState('');
-  const { data, refetch } = useQuery<{ data: Comment[] }>({
+  const { data: comments = [], refetch } = useQuery<Comment[]>({
     queryKey: [resource, 'comments'],
-    queryFn: () => apiFetch(`/internal/${resource}/comments`),
+    queryFn: () => listComments(resource),
   });
 
   const mutation = useMutation({
-    mutationFn: async () => {
-      await apiFetch(`/internal/${resource}/comments`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ text }),
-      });
-    },
+    mutationFn: async () => addComment(resource, text),
     onSuccess: () => {
       setText('');
       refetch();
@@ -33,8 +21,8 @@ export default function CommentPanel({ resource }: { resource: string }) {
     <div>
       <h3>Comments</h3>
       <ul>
-        {(data?.data || []).map((c, i) => (
-          <li key={c.id || i}>{c.text}</li>
+        {comments.map((c) => (
+          <li key={c.id}>{c.content}</li>
         ))}
       </ul>
       <form

--- a/apps/crm-server/src/db/sql/comments.ts
+++ b/apps/crm-server/src/db/sql/comments.ts
@@ -1,0 +1,36 @@
+export const createCommentsTable = `
+  CREATE TABLE IF NOT EXISTS comments (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    entity_id VARCHAR(255) NOT NULL,
+    content TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+  )`;
+
+export const listComments = `
+  SELECT id, entity_id, content, created_at
+  FROM comments
+  WHERE entity_id = ?
+  ORDER BY id ASC
+`;
+
+export const getComment = `
+  SELECT id, entity_id, content, created_at
+  FROM comments
+  WHERE id = ?
+`;
+
+export const insertComment = `
+  INSERT INTO comments (entity_id, content)
+  VALUES (?, ?)
+`;
+
+export const updateComment = `
+  UPDATE comments
+  SET content = ?
+  WHERE id = ? AND entity_id = ?
+`;
+
+export const deleteComment = `
+  DELETE FROM comments
+  WHERE id = ? AND entity_id = ?
+`;

--- a/apps/crm-server/src/index.ts
+++ b/apps/crm-server/src/index.ts
@@ -9,6 +9,7 @@ import walletsRoutes from './routes/wallets.js';
 import depositsRoutes from './routes/deposits.js';
 import withdrawalsRoutes from './routes/withdrawals.js';
 import internalRoutes from './routes/internal.js';
+import commentsRoutes from './routes/comments.js';
 
 import { requireAuth, requirePerm } from './middleware/auth.js';
 import { rateLimit } from './middleware/rateLimit.js';
@@ -27,6 +28,7 @@ app.use('/internal/wallets', requireAuth, walletsRoutes);
 app.use('/internal/deposits', requireAuth, depositsRoutes);
 app.use('/internal/withdrawals', requireAuth, withdrawalsRoutes);
 app.use('/internal', requireAuth, internalRoutes);
+app.use('/api/comments', requireAuth, commentsRoutes);
 
 app.use(errorHandler);
 

--- a/apps/crm-server/src/routes/comments.ts
+++ b/apps/crm-server/src/routes/comments.ts
@@ -1,0 +1,53 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { pool, query } from '../db/db.js';
+import {
+  createCommentsTable,
+  listComments,
+  getComment,
+  insertComment,
+  updateComment as updateCommentSql,
+  deleteComment as deleteCommentSql,
+} from '../db/sql/comments.js';
+
+const router = Router();
+
+const asyncHandler = (fn: any) => (req: Request, res: Response, next: NextFunction) =>
+  Promise.resolve(fn(req, res, next)).catch(next);
+
+router.use(asyncHandler(async (_req: Request, _res: Response, next: NextFunction) => {
+  await query(createCommentsTable);
+  next();
+}));
+
+router.get('/', asyncHandler(async (req: Request, res: Response) => {
+  const { entityId } = req.query as { entityId: string };
+  const rows = await query<any>(listComments, [entityId]);
+  res.json(rows);
+}));
+
+router.post('/', asyncHandler(async (req: Request, res: Response) => {
+  const { entityId } = req.query as { entityId: string };
+  const { content } = req.body;
+  const [result]: any = await pool.query(insertComment, [entityId, content]);
+  const id = result.insertId;
+  const [rows] = await pool.query<any[]>(getComment, [id]);
+  res.json(rows[0]);
+}));
+
+router.put('/:id', asyncHandler(async (req: Request, res: Response) => {
+  const { entityId } = req.query as { entityId: string };
+  const { content } = req.body;
+  const id = Number(req.params.id);
+  await pool.query(updateCommentSql, [content, id, entityId]);
+  const [rows] = await pool.query<any[]>(getComment, [id]);
+  res.json(rows[0]);
+}));
+
+router.delete('/:id', asyncHandler(async (req: Request, res: Response) => {
+  const { entityId } = req.query as { entityId: string };
+  const id = Number(req.params.id);
+  await pool.query(deleteCommentSql, [id, entityId]);
+  res.json({ ok: true });
+}));
+
+export default router;


### PR DESCRIPTION
## Summary
- implement SQL helpers and Express router for comments
- expose comments API at `/api/comments`
- hook comment panel into new comments endpoints

## Testing
- `npm test -w apps/crm-server` *(fails: Missing script "test")*
- `npm run build -w apps/crm-server`
- `npm test -w apps/crm-frontend` *(fails: Missing script "test")*
- `npm run build -w apps/crm-frontend`


------
https://chatgpt.com/codex/tasks/task_e_68a7780627dc8322ac2c107290583124