### PR TITLE
Add admin endpoints and pages for settings, cron jobs, audit logs, and alerts

### DIFF
--- a/apps/crm-frontend/src/App.tsx
+++ b/apps/crm-frontend/src/App.tsx
@@ -17,6 +17,8 @@ import CronJobs from './pages/admin/CronJobs';
 import Kyc from './pages/admin/Kyc';
 import NotificationTemplates from './pages/admin/NotificationTemplates';
 import SystemInfo from './pages/admin/SystemInfo';
+import AuditLogs from './pages/admin/AuditLogs';
+import Alerts from './pages/admin/Alerts';
 
 import BinaryTrades from './pages/admin/binary-trades';
 import P2PAdmin from './pages/admin/p2p';
@@ -77,8 +79,8 @@ export default function App() {
       <Route path="/system/cron" element={token ? <CronJobs /> : <Navigate to="/login" />} />
       <Route path="/system/info" element={token ? <SystemInfo /> : <Navigate to="/login" />} />
 
-      <Route path="/system/audit" element={token ? <Placeholder title="Audit Logs" /> : <Navigate to="/login" />} />
-      <Route path="/system/alerts" element={token ? <Placeholder title="Alerts" /> : <Navigate to="/login" />} />
+      <Route path="/system/audit" element={token ? <AuditLogs /> : <Navigate to="/login" />} />
+      <Route path="/system/alerts" element={token ? <Alerts /> : <Navigate to="/login" />} />
       <Route path="/*" element={token ? <Dashboard /> : <Navigate to="/login" />} />
     </Routes>
   );

--- a/apps/crm-frontend/src/api/alerts.ts
+++ b/apps/crm-frontend/src/api/alerts.ts
@@ -1,0 +1,9 @@
+import { apiFetch } from './client';
+
+const base = '/internal/alerts';
+
+export const list = (params: any = {}) => {
+  const query = new URLSearchParams(params).toString();
+  const path = query ? `${base}?${query}` : base;
+  return apiFetch(path);
+};

--- a/apps/crm-frontend/src/api/audit.ts
+++ b/apps/crm-frontend/src/api/audit.ts
@@ -1,0 +1,9 @@
+import { apiFetch } from './client';
+
+const base = '/internal/audit';
+
+export const list = (params: any = {}) => {
+  const query = new URLSearchParams(params).toString();
+  const path = query ? `${base}?${query}` : base;
+  return apiFetch(path);
+};

--- a/apps/crm-frontend/src/pages/admin/Alerts.tsx
+++ b/apps/crm-frontend/src/pages/admin/Alerts.tsx
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query';
+import CommentPanel from '../../components/admin/comment-panel';
+import * as alerts from '../../api/alerts';
+
+export default function Alerts() {
+  const { data } = useQuery({ queryKey: ['alerts'], queryFn: () => alerts.list() });
+  return (
+    <div>
+      <h1>Alerts</h1>
+      <pre>{JSON.stringify(data, null, 2)}</pre>
+      <CommentPanel resource="alerts" />
+    </div>
+  );
+}

--- a/apps/crm-frontend/src/pages/admin/AuditLogs.tsx
+++ b/apps/crm-frontend/src/pages/admin/AuditLogs.tsx
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query';
+import CommentPanel from '../../components/admin/comment-panel';
+import * as audit from '../../api/audit';
+
+export default function AuditLogs() {
+  const { data } = useQuery({ queryKey: ['audit-logs'], queryFn: () => audit.list() });
+  return (
+    <div>
+      <h1>Audit Logs</h1>
+      <pre>{JSON.stringify(data, null, 2)}</pre>
+      <CommentPanel resource="audit-logs" />
+    </div>
+  );
+}

--- a/apps/crm-server/src/db/sql/alerts.ts
+++ b/apps/crm-server/src/db/sql/alerts.ts
@@ -1,0 +1,1 @@
+export const listAlerts = `SELECT id, message, level, created_at FROM alerts ORDER BY id DESC LIMIT ? OFFSET ?`;

--- a/apps/crm-server/src/db/sql/audit.ts
+++ b/apps/crm-server/src/db/sql/audit.ts
@@ -1,0 +1,1 @@
+export const listAuditLogs = `SELECT id, admin_id, action, meta, created_at FROM audit_logs ORDER BY id DESC LIMIT ? OFFSET ?`;

--- a/apps/crm-server/src/db/sql/cron.ts
+++ b/apps/crm-server/src/db/sql/cron.ts
@@ -1,0 +1,9 @@
+export const listCronJobs = `SELECT id, name, schedule, status FROM cron_jobs ORDER BY id DESC`;
+
+export const insertCronJob = `INSERT INTO cron_jobs (name, schedule, status) VALUES (?, ?, ?)`;
+
+export const updateCronJob = `UPDATE cron_jobs SET name = ?, schedule = ?, status = ? WHERE id = ?`;
+
+export const deleteCronJob = `DELETE FROM cron_jobs WHERE id = ?`;
+
+export const toggleCronJob = `UPDATE cron_jobs SET status = IF(status='active','inactive','active') WHERE id = ?`;

--- a/apps/crm-server/src/db/sql/settings.ts
+++ b/apps/crm-server/src/db/sql/settings.ts
@@ -1,0 +1,7 @@
+export const listSettings = `SELECT id, \`key\`, \`value\`, status FROM settings ORDER BY id DESC`;
+
+export const insertSetting = `INSERT INTO settings (\`key\`, \`value\`, status) VALUES (?, ?, ?)`;
+
+export const updateSetting = `UPDATE settings SET \`key\` = ?, \`value\` = ?, status = ? WHERE id = ?`;
+
+export const deleteSetting = `DELETE FROM settings WHERE id = ?`;


### PR DESCRIPTION
## Summary
- add SQL tables and queries for settings, cron jobs, audit logs, and alerts
- implement `/internal/settings`, `/internal/cron`, `/internal/audit`, and `/internal/alerts` server routes
- build admin UI pages and API clients for settings, cron jobs, audit logs, and alerts

## Testing
- `npm run build -w apps/crm-server`
- `npm run build -w apps/crm-frontend`


------
https://chatgpt.com/codex/tasks/task_e_68a777feeff08322ac45e981fbe43c16