### PR TITLE
Implement internal reports and expose frontend pages

### DIFF
--- a/apps/crm-frontend/src/App.tsx
+++ b/apps/crm-frontend/src/App.tsx
@@ -10,6 +10,11 @@ import Trades from './pages/Trades';
 import Notifications from './pages/Notifications';
 import Settings from './pages/Settings';
 import Placeholder from './pages/Placeholder';
+import Reports from './pages/Reports';
+import ReportTransactions from './pages/ReportTransactions';
+import ReportLogins from './pages/ReportLogins';
+import ReportNotifications from './pages/ReportNotifications';
+import ReportAgentPerformance from './pages/ReportAgentPerformance';
 import Referrals from './pages/admin/Referrals';
 import CoinPairs from './pages/admin/CoinPairs';
 import GeneralSettings from './pages/admin/GeneralSettings';
@@ -68,7 +73,11 @@ export default function App() {
       <Route path="/crm/tasks" element={token ? <Placeholder title="CRM Tasks" /> : <Navigate to="/login" />} />
       <Route path="/crm/notes" element={token ? <Placeholder title="CRM Notes" /> : <Navigate to="/login" />} />
       <Route path="/crm/chat" element={token ? <Placeholder title="CRM Staff Chat" /> : <Navigate to="/login" />} />
-      <Route path="/reports" element={token ? <Placeholder title="Reports" /> : <Navigate to="/login" />} />
+      <Route path="/reports" element={token ? <Reports /> : <Navigate to="/login" />} />
+      <Route path="/reports/transactions" element={token ? <ReportTransactions /> : <Navigate to="/login" />} />
+      <Route path="/reports/logins" element={token ? <ReportLogins /> : <Navigate to="/login" />} />
+      <Route path="/reports/notifications" element={token ? <ReportNotifications /> : <Navigate to="/login" />} />
+      <Route path="/reports/agent-performance" element={token ? <ReportAgentPerformance /> : <Navigate to="/login" />} />
 
       <Route path="/settings" element={token ? <Settings /> : <Navigate to="/login" />} />
       <Route path="/system/cron" element={token ? <Placeholder title="System Cron" /> : <Navigate to="/login" />} />

--- a/apps/crm-frontend/src/pages/ReportAgentPerformance.tsx
+++ b/apps/crm-frontend/src/pages/ReportAgentPerformance.tsx
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiFetch } from '../api/client';
+
+export default function ReportAgentPerformance() {
+  const { data } = useQuery({
+    queryKey: ['report-agent-performance'],
+    queryFn: () => apiFetch('/internal/reports/agent-performance')
+  });
+  return (
+    <div>
+      <h1>Agent Performance Report</h1>
+      <pre>{JSON.stringify(data, null, 2)}</pre>
+    </div>
+  );
+}

--- a/apps/crm-frontend/src/pages/ReportLogins.tsx
+++ b/apps/crm-frontend/src/pages/ReportLogins.tsx
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiFetch } from '../api/client';
+
+export default function ReportLogins() {
+  const { data } = useQuery({
+    queryKey: ['report-logins'],
+    queryFn: () => apiFetch('/internal/reports/logins')
+  });
+  return (
+    <div>
+      <h1>Logins Report</h1>
+      <pre>{JSON.stringify(data, null, 2)}</pre>
+    </div>
+  );
+}

--- a/apps/crm-frontend/src/pages/ReportNotifications.tsx
+++ b/apps/crm-frontend/src/pages/ReportNotifications.tsx
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiFetch } from '../api/client';
+
+export default function ReportNotifications() {
+  const { data } = useQuery({
+    queryKey: ['report-notifications'],
+    queryFn: () => apiFetch('/internal/reports/notifications')
+  });
+  return (
+    <div>
+      <h1>Notifications Report</h1>
+      <pre>{JSON.stringify(data, null, 2)}</pre>
+    </div>
+  );
+}

--- a/apps/crm-frontend/src/pages/ReportTransactions.tsx
+++ b/apps/crm-frontend/src/pages/ReportTransactions.tsx
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiFetch } from '../api/client';
+
+export default function ReportTransactions() {
+  const { data } = useQuery({
+    queryKey: ['report-transactions'],
+    queryFn: () => apiFetch('/internal/reports/transactions')
+  });
+  return (
+    <div>
+      <h1>Transactions Report</h1>
+      <pre>{JSON.stringify(data, null, 2)}</pre>
+    </div>
+  );
+}

--- a/apps/crm-frontend/src/pages/Reports.tsx
+++ b/apps/crm-frontend/src/pages/Reports.tsx
@@ -1,0 +1,13 @@
+export default function Reports() {
+  return (
+    <div>
+      <h1>Reports</h1>
+      <ul>
+        <li><a href="/reports/transactions">Transactions</a></li>
+        <li><a href="/reports/logins">Logins</a></li>
+        <li><a href="/reports/notifications">Notifications</a></li>
+        <li><a href="/reports/agent-performance">Agent Performance</a></li>
+      </ul>
+    </div>
+  );
+}

--- a/apps/crm-server/src/auth/permissions.ts
+++ b/apps/crm-server/src/auth/permissions.ts
@@ -6,7 +6,8 @@ export type Action =
   | 'deposits.read'
   | 'deposits.write'
   | 'withdrawals.read'
-  | 'withdrawals.write';
+  | 'withdrawals.write'
+  | 'reports.read';
 
 export const rolePermissions: Record<string, Action[]> = {
   admin: [
@@ -17,9 +18,10 @@ export const rolePermissions: Record<string, Action[]> = {
     'deposits.read',
     'deposits.write',
     'withdrawals.read',
-    'withdrawals.write'
+    'withdrawals.write',
+    'reports.read'
   ],
-  agent: ['dashboard.read', 'users.read', 'wallets.read', 'deposits.read', 'withdrawals.read'],
+  agent: ['dashboard.read', 'users.read', 'wallets.read', 'deposits.read', 'withdrawals.read', 'reports.read'],
   support: ['dashboard.read', 'users.read']
 };
 

--- a/apps/crm-server/src/db/sql/reports.ts
+++ b/apps/crm-server/src/db/sql/reports.ts
@@ -1,0 +1,40 @@
+export const transactions = `
+  SELECT DATE(created_at) AS date,
+         COUNT(*) AS total,
+         SUM(amount) AS volume,
+         SUM(CASE WHEN trx_type = '+' THEN amount ELSE 0 END) AS credit,
+         SUM(CASE WHEN trx_type = '-' THEN amount ELSE 0 END) AS debit
+  FROM transactions
+  GROUP BY DATE(created_at)
+  ORDER BY date DESC
+  LIMIT 30
+`;
+
+export const logins = `
+  SELECT DATE(created_at) AS date,
+         COUNT(*) AS logins
+  FROM user_logins
+  GROUP BY DATE(created_at)
+  ORDER BY date DESC
+  LIMIT 30
+`;
+
+export const notifications = `
+  SELECT DATE(created_at) AS date,
+         COUNT(*) AS notifications,
+         SUM(is_read = 0) AS unread
+  FROM admin_notifications
+  GROUP BY DATE(created_at)
+  ORDER BY date DESC
+  LIMIT 30
+`;
+
+export const agentPerformance = `
+  SELECT a.id,
+         a.username,
+         COUNT(u.id) AS users
+  FROM admins a
+  LEFT JOIN users u ON u.ref_by = a.id
+  GROUP BY a.id, a.username
+  ORDER BY users DESC
+`;

--- a/apps/crm-server/src/routes/internal.ts
+++ b/apps/crm-server/src/routes/internal.ts
@@ -1,7 +1,12 @@
-import { Router } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
+import { query, assertTableExists } from '../db/db.js';
+import * as reports from '../db/sql/reports.js';
 import { requirePerm } from '../middleware/auth.js';
 
 const router = Router();
+
+const asyncHandler = (fn: any) => (req: Request, res: Response, next: NextFunction) =>
+  Promise.resolve(fn(req, res, next)).catch(next);
 
 const perm = (action: string) => requirePerm(action as any);
 
@@ -57,10 +62,26 @@ router.get('/crm/chat', perm('crm.read'), notImplemented);
 router.post('/crm/chat', perm('crm.write'), notImplemented);
 
 // Reports
-router.get('/reports/transactions', perm('reports.read'), notImplemented);
-router.get('/reports/logins', perm('reports.read'), notImplemented);
-router.get('/reports/notifications', perm('reports.read'), notImplemented);
-router.get('/reports/agent-performance', perm('reports.read'), notImplemented);
+router.get('/reports/transactions', perm('reports.read'), asyncHandler(async (_req: Request, res: Response) => {
+  if (!(await assertTableExists('transactions'))) return res.json([]);
+  const rows = await query<any>(reports.transactions);
+  res.json(rows);
+}));
+router.get('/reports/logins', perm('reports.read'), asyncHandler(async (_req: Request, res: Response) => {
+  if (!(await assertTableExists('user_logins'))) return res.json([]);
+  const rows = await query<any>(reports.logins);
+  res.json(rows);
+}));
+router.get('/reports/notifications', perm('reports.read'), asyncHandler(async (_req: Request, res: Response) => {
+  if (!(await assertTableExists('admin_notifications'))) return res.json([]);
+  const rows = await query<any>(reports.notifications);
+  res.json(rows);
+}));
+router.get('/reports/agent-performance', perm('reports.read'), asyncHandler(async (_req: Request, res: Response) => {
+  if (!(await assertTableExists('admins')) || !(await assertTableExists('users'))) return res.json([]);
+  const rows = await query<any>(reports.agentPerformance);
+  res.json(rows);
+}));
 
 // Settings
 router.get('/settings', perm('settings.read'), notImplemented);


### PR DESCRIPTION
## Summary
- add `reports.read` permission for viewing new reports
- implement `/internal/reports/*` endpoints with SQL aggregation
- create React pages to display transactions, logins, notifications and agent performance reports

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build -w apps/crm-server`
- `npm run build -w apps/crm-frontend`


------
https://chatgpt.com/codex/tasks/task_e_68a777f9d9e48322ad78f03240cea6ba