### PR TITLE
Fix CRM server build and startup issues

### DIFF
--- a/apps/crm-server/src/auth/permissions.ts
+++ b/apps/crm-server/src/auth/permissions.ts
@@ -13,10 +13,10 @@ export type Action =
   | 'futures.positions.read'
   | 'futures.orders.read'
   | 'binary.trades.read'
-  | 'binary.trades.write';
+  | 'binary.trades.write'
   | 'crm.read'
-  | 'crm.write';
-  | 'reports.read';
+  | 'crm.write'
+  | 'reports.read'
   | 'support.read'
   | 'support.write';
 
@@ -36,7 +36,12 @@ export const rolePermissions: Record<string, Action[]> = {
     'futures.positions.read',
     'futures.orders.read',
     'binary.trades.read',
-    'binary.trades.write'
+    'binary.trades.write',
+    'crm.read',
+    'crm.write',
+    'reports.read',
+    'support.read',
+    'support.write'
   ],
   agent: [
     'dashboard.read',
@@ -48,28 +53,16 @@ export const rolePermissions: Record<string, Action[]> = {
     'spot.trades.read',
     'futures.positions.read',
     'futures.orders.read',
-    'binary.trades.read'
-  ],
+    'binary.trades.read',
     'crm.read',
-    'crm.write'
-  ],
-  agent: [
-    'dashboard.read',
-    'users.read',
-    'wallets.read',
-    'deposits.read',
-    'withdrawals.read',
-    'crm.read',
-    'crm.write'
-  ],
+    'crm.write',
     'reports.read'
   ],
-  agent: ['dashboard.read', 'users.read', 'wallets.read', 'deposits.read', 'withdrawals.read', 'reports.read'],
-  support: ['dashboard.read', 'users.read']
+  support: [
+    'dashboard.read',
+    'users.read',
     'support.read',
     'support.write'
-  ],
-  agent: ['dashboard.read', 'users.read', 'wallets.read', 'deposits.read', 'withdrawals.read'],
-  support: ['dashboard.read', 'users.read', 'support.read', 'support.write']
+  ]
 };
 

--- a/apps/crm-server/src/routes/files.ts
+++ b/apps/crm-server/src/routes/files.ts
@@ -9,7 +9,7 @@ const asyncHandler = (fn: any) => (req: Request, res: Response, next: NextFuncti
 
 const router = Router();
 
-const storageRoot = process.env.FILE_STORAGE_ROOT!;
+const storageRoot = process.env.FILE_STORAGE_ROOT || path.join(process.cwd(), 'storage');
 const upload = multer({ dest: path.join(storageRoot, 'tmp') });
 
 router.post('/upload', upload.single('file'), asyncHandler(async (req: Request, res: Response) => {

--- a/apps/crm-server/src/routes/internal.ts
+++ b/apps/crm-server/src/routes/internal.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response, NextFunction } from 'express';
 import { requirePerm } from '../middleware/auth.js';
-import { query } from '../db/db.js';
+import { query, pool, assertTableExists } from '../db/db.js';
+import { HttpError } from '../middleware/error.js';
 import {
   listSpotOrders,
   cancelSpotOrder,
@@ -10,8 +11,6 @@ import {
   listBinaryTrades,
   refundBinaryTrade
 } from '../db/sql/trading.js';
-import { pool, assertTableExists } from '../db/db.js';
-import { HttpError } from '../middleware/error.js';
 import {
   listAds,
   insertAd,
@@ -23,7 +22,6 @@ import {
   insertTradeMessage,
   resolveDispute
 } from '../db/sql/p2p.js';
-import { query } from '../db/db.js';
 import {
   listLeads,
   insertLead,
@@ -41,14 +39,12 @@ import {
   listChat,
   insertChat
 } from '../db/sql/crm.js';
-import { query, assertTableExists } from '../db/db.js';
 import * as reports from '../db/sql/reports.js';
-import { requirePerm } from '../middleware/auth.js';
-import { query } from '../db/db.js';
 import * as settingsSql from '../db/sql/settings.js';
 import * as cronSql from '../db/sql/cron.js';
 import * as auditSql from '../db/sql/audit.js';
 import * as alertsSql from '../db/sql/alerts.js';
+
 
 const router = Router();
 
@@ -57,8 +53,6 @@ const asyncHandler = (fn: any) => (req: Request, res: Response, next: NextFuncti
 
 const perm = (action: string) => requirePerm(action as any);
 
-const asyncHandler = (fn: any) => (req: Request, res: Response, next: NextFunction) =>
-  Promise.resolve(fn(req, res, next)).catch(next);
 
 function notImplemented(_req: any, res: any) {
   res.status(501).json({ error: 'not implemented' });


### PR DESCRIPTION
## Summary
- Clean up duplicate imports and handler declarations in internal routes
- Restore consolidated permission definitions and role mappings
- Add default file storage path to avoid startup failure when `FILE_STORAGE_ROOT` is unset

## Testing
- `npm run build -w packages/shared`
- `npm run build -w apps/crm-frontend`
- `npm run build -w apps/crm-server`
- `PORT=3000 npm start -w apps/crm-server`
- `npm run dev -w apps/crm-frontend`

------
https://chatgpt.com/codex/tasks/task_e_68a8814cae788322a9259da23ef04c84